### PR TITLE
Fixes for older compilers

### DIFF
--- a/releasenotes/notes/fix_for_older_compilers-6644b7b1db0ff9a1.yaml
+++ b/releasenotes/notes/fix_for_older_compilers-6644b7b1db0ff9a1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Qiskit C++ compilation failed on older compilers.
+    With this fix, at least C++11 is required to compile.

--- a/src/circuit/circuitinstruction.hpp
+++ b/src/circuit/circuitinstruction.hpp
@@ -45,7 +45,7 @@ public:
     /// @param inst The instruction
     /// @param qubits The list of qubits for the instruction
     /// @param clbits The list of clbits for the instruction
-    CircuitInstruction(Instruction& inst, reg_t qubits, reg_t clbits = reg_t())
+    CircuitInstruction(const Instruction& inst, reg_t qubits, reg_t clbits = reg_t())
     {
         inst_ = inst;
         qubits_ = qubits;
@@ -54,7 +54,7 @@ public:
 
     /// @brief Create a new instruction
     /// @param other The instruction to be copoed
-    CircuitInstruction(CircuitInstruction& other)
+    CircuitInstruction(const CircuitInstruction& other)
     {
         inst_ = other.inst_;
         qubits_ = other.qubits_;
@@ -83,13 +83,13 @@ public:
 
     /// @brief Return number of qubits
     /// @return number of qubits
-    const uint_t num_qubits(void) const
+    uint_t num_qubits(void) const
     {
         return qubits_.size();
     }
     /// @brief Return number of clbits
     /// @return number of clbits
-    const uint_t num_clbits(void) const
+    uint_t num_clbits(void) const
     {
         return clbits_.size();
     }
@@ -99,16 +99,9 @@ public:
     {
         return label_;
     }
-
 };
-
-
-
-
-
 
 } // namespace circuit
 } // namespace Qiskit
-
 
 #endif  // __qiskitcpp_circuit_circuit_instruction_def_hpp__

--- a/src/circuit/controlflow/if_else.hpp
+++ b/src/circuit/controlflow/if_else.hpp
@@ -37,7 +37,7 @@ public:
   /// @param (circ)
   /// @param (clbit)
   /// @param (value)
-  IfElseOp(QuantumCircuit& circ, uint32_t clbit, uint32_t value) : ControlFlowOp(clbit, value), true_body_(circ), false_body_(circ) {}
+  IfElseOp(const QuantumCircuit& circ, uint32_t clbit, uint32_t value) : ControlFlowOp(clbit, value), true_body_(circ), false_body_(circ) {}
 
   /// @brief Return true body available in this operator
   /// @return true body

--- a/src/circuit/instruction.hpp
+++ b/src/circuit/instruction.hpp
@@ -63,7 +63,7 @@ public:
 
     /// @brief Create a new instruction
     /// @param other The instruction to be copoed
-    Instruction(Instruction& other)
+    Instruction(const Instruction& other)
     {
         name_ = other.name_;
         num_qubits_ = other.num_qubits_;
@@ -80,13 +80,13 @@ public:
     }
     /// @brief Return number of qubits
     /// @return number of qubits
-    const uint_t num_qubits(void) const
+    uint_t num_qubits(void) const
     {
         return num_qubits_;
     }
     /// @brief Return number of clbits
     /// @return number of clbits
-    const uint_t num_clbits(void) const
+    uint_t num_clbits(void) const
     {
         return num_clbits_;
     }
@@ -126,28 +126,28 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    virtual const uint_t num_controll_bits(void) const
+    virtual uint_t num_controll_bits(void) const
     {
         return 0;
     }
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    virtual const uint_t num_params(void) const
+    virtual uint_t num_params(void) const
     {
         return 0;
     }
 
     /// @brief Return gate enum for Qiskit C-API
     /// @return QkGate enum for this instruciton
-    virtual const QkGate gate_map(void) const
+    virtual QkGate gate_map(void) const
     {
         return map_;
     }
 
     /// @brief check if this isntruction is a standard gate
     /// @return true if the instruction is a standard gate
-    virtual const bool is_standard_gate(void) const
+    virtual bool is_standard_gate(void) const
     {
         return is_standard_gate_;
     }

--- a/src/circuit/library/standard_gates/global_phase.hpp
+++ b/src/circuit/library/standard_gates/global_phase.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/h.hpp
+++ b/src/circuit/library/standard_gates/h.hpp
@@ -53,7 +53,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/p.hpp
+++ b/src/circuit/library/standard_gates/p.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }
@@ -60,14 +60,14 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/r.hpp
+++ b/src/circuit/library/standard_gates/r.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/rx.hpp
+++ b/src/circuit/library/standard_gates/rx.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }
@@ -60,14 +60,14 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/rxx.hpp
+++ b/src/circuit/library/standard_gates/rxx.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/ry.hpp
+++ b/src/circuit/library/standard_gates/ry.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }
@@ -60,14 +60,14 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/ryy.hpp
+++ b/src/circuit/library/standard_gates/ryy.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/rz.hpp
+++ b/src/circuit/library/standard_gates/rz.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }
@@ -60,14 +60,14 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/rzx.hpp
+++ b/src/circuit/library/standard_gates/rzx.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/rzz.hpp
+++ b/src/circuit/library/standard_gates/rzz.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/s.hpp
+++ b/src/circuit/library/standard_gates/s.hpp
@@ -69,7 +69,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
@@ -91,7 +91,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/standard_gates.hpp
+++ b/src/circuit/library/standard_gates/standard_gates.hpp
@@ -17,6 +17,8 @@
 #ifndef __qiskitcpp_circuit_library_standard_gates_def_hpp__
 #define __qiskitcpp_circuit_library_standard_gates_def_hpp__
 
+#include <unordered_map>
+
 #include "circuit/library/standard_gates/dcx.hpp"
 #include "circuit/library/standard_gates/ecr.hpp"
 #include "circuit/library/standard_gates/global_phase.hpp"

--- a/src/circuit/library/standard_gates/swap.hpp
+++ b/src/circuit/library/standard_gates/swap.hpp
@@ -53,7 +53,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/sx.hpp
+++ b/src/circuit/library/standard_gates/sx.hpp
@@ -69,7 +69,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/u.hpp
+++ b/src/circuit/library/standard_gates/u.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 3;
     }
@@ -60,14 +60,14 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 3;
     }

--- a/src/circuit/library/standard_gates/u1.hpp
+++ b/src/circuit/library/standard_gates/u1.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }
@@ -60,14 +60,14 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/u2.hpp
+++ b/src/circuit/library/standard_gates/u2.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 2;
     }

--- a/src/circuit/library/standard_gates/u3.hpp
+++ b/src/circuit/library/standard_gates/u3.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 3;
     }
@@ -60,14 +60,14 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 3;
     }

--- a/src/circuit/library/standard_gates/x.hpp
+++ b/src/circuit/library/standard_gates/x.hpp
@@ -53,7 +53,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
@@ -75,7 +75,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 2;
     }
@@ -97,7 +97,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 3;
     }
@@ -119,7 +119,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 3;
     }
@@ -142,7 +142,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 2;
     }
@@ -164,7 +164,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 3;
     }
@@ -197,7 +197,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return num_qubits_ - 1;
     }

--- a/src/circuit/library/standard_gates/xx_minus_yy.hpp
+++ b/src/circuit/library/standard_gates/xx_minus_yy.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 2;
     }

--- a/src/circuit/library/standard_gates/xx_plus_yy.hpp
+++ b/src/circuit/library/standard_gates/xx_plus_yy.hpp
@@ -38,7 +38,7 @@ public:
 
     /// @brief Return number of parameters for this instruction
     /// @return number of parameters
-    const uint_t num_params(void) const override
+    uint_t num_params(void) const override
     {
         return 2;
     }

--- a/src/circuit/library/standard_gates/y.hpp
+++ b/src/circuit/library/standard_gates/y.hpp
@@ -53,7 +53,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }

--- a/src/circuit/library/standard_gates/z.hpp
+++ b/src/circuit/library/standard_gates/z.hpp
@@ -53,7 +53,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 1;
     }
@@ -75,7 +75,7 @@ public:
 
     /// @brief Return number of control bits for this instruction
     /// @return number of control bits
-    const uint_t num_controll_bits(void) const override
+    uint_t num_controll_bits(void) const override
     {
         return 2;
     }

--- a/src/circuit/quantumcircuit_impl.hpp
+++ b/src/circuit/quantumcircuit_impl.hpp
@@ -243,7 +243,7 @@ void QuantumCircuit::p(const double phase, const uint_t qubit)
 
 void QuantumCircuit::p(const Parameter &phase, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
 //  qc_p(rust_circuit_.get(), theta.expr_, qubit);
@@ -259,7 +259,7 @@ void QuantumCircuit::r(const double theta, const double phi, const uint_t qubit)
 
 void QuantumCircuit::r(const Parameter &theta, const Parameter &phi, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
 //  qc_r(rust_circuit_.get(), theta.expr_, phi.expr_, qubit);
@@ -274,7 +274,7 @@ void QuantumCircuit::rx(const double theta, const uint_t qubit)
 
 void QuantumCircuit::rx(const Parameter &theta, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_rx(rust_circuit_.get(), theta.expr_, qubit);
@@ -289,7 +289,7 @@ void QuantumCircuit::ry(const double theta, const uint_t qubit)
 
 void QuantumCircuit::ry(const Parameter &theta, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_ry(rust_circuit_.get(), theta.expr_, qubit);
@@ -304,7 +304,7 @@ void QuantumCircuit::rz(const double theta, const uint_t qubit)
 
 void QuantumCircuit::rz(const Parameter &theta, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_rz(rust_circuit_.get(), theta.expr_, qubit);
@@ -362,7 +362,7 @@ void QuantumCircuit::u(const double theta, const double phi, const double lam, c
 
 void QuantumCircuit::u(const Parameter &theta, const Parameter &phi, const Parameter &lam, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_u(rust_circuit_.get(), theta.expr_, phi.expr_, lam.expr_, qubit);
@@ -378,7 +378,7 @@ void QuantumCircuit::u1(const double theta, const uint_t qubit)
 
 void QuantumCircuit::u1(const Parameter &theta, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_u(rust_circuit_.get(), theta.expr_, phi.expr_, lam.expr_, qubit);
@@ -394,7 +394,7 @@ void QuantumCircuit::u2(const double phi, const double lam, const uint_t qubit)
 
 void QuantumCircuit::u2(const Parameter &phi, const Parameter &lam, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_u(rust_circuit_.get(), theta.expr_, phi.expr_, lam.expr_, qubit);
@@ -410,7 +410,7 @@ void QuantumCircuit::u3(const double theta, const double phi, const double lam, 
 
 void QuantumCircuit::u3(const Parameter &theta, const Parameter &phi, const Parameter &lam, const uint_t qubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_u(rust_circuit_.get(), theta.expr_, phi.expr_, lam.expr_, qubit);
@@ -491,7 +491,7 @@ void QuantumCircuit::cp(const double phase, const uint_t cqubit, const uint_t tq
 
 void QuantumCircuit::cp(const Parameter &phase, const uint_t cqubit, const uint_t tqubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
   pre_add_gate();
   //TO DO support parameter expression
 //  qc_p(rust_circuit_.get(), theta.expr_, qubit);
@@ -506,7 +506,7 @@ void QuantumCircuit::crx(const double theta, const uint_t cqubit, const uint_t t
 
 void QuantumCircuit::crx(const Parameter &theta, const uint_t cqubit, const uint_t tqubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
   pre_add_gate();
   //TO DO support parameter expression
 //  qc_p(rust_circuit_.get(), theta.expr_, qubit);
@@ -521,7 +521,7 @@ void QuantumCircuit::cry(const double theta, const uint_t cqubit, const uint_t t
 
 void QuantumCircuit::cry(const Parameter &theta, const uint_t cqubit, const uint_t tqubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
   pre_add_gate();
   //TO DO support parameter expression
 //  qc_p(rust_circuit_.get(), theta.expr_, qubit);
@@ -536,7 +536,7 @@ void QuantumCircuit::crz(const double theta, const uint_t cqubit, const uint_t t
 
 void QuantumCircuit::crz(const Parameter &theta, const uint_t cqubit, const uint_t tqubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
   pre_add_gate();
   //TO DO support parameter expression
 //  qc_p(rust_circuit_.get(), theta.expr_, qubit);
@@ -573,7 +573,7 @@ void QuantumCircuit::cu(const double theta, const double phi, const double lam, 
 
 void QuantumCircuit::cu(const Parameter &theta, const Parameter &phi, const Parameter &lam, const uint_t cqubit, const uint_t tqubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_u(rust_circuit_.get(), theta.expr_, phi.expr_, lam.expr_, qubit);
@@ -589,7 +589,7 @@ void QuantumCircuit::cu1(const double theta, const uint_t cqubit, const uint_t t
 
 void QuantumCircuit::cu1(const Parameter &theta, const uint_t cqubit, const uint_t tqubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_u(rust_circuit_.get(), theta.expr_, phi.expr_, lam.expr_, qubit);
@@ -605,7 +605,7 @@ void QuantumCircuit::cu3(const double theta, const double phi, const double lam,
 
 void QuantumCircuit::cu3(const Parameter &theta, const Parameter &phi, const Parameter &lam, const uint_t cqubit, const uint_t tqubit)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
+  //std::uint32_t qubits[] = {(std::uint32_t)cqubit, (std::uint32_t)tqubit};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_u(rust_circuit_.get(), theta.expr_, phi.expr_, lam.expr_, qubit);
@@ -620,7 +620,7 @@ void QuantumCircuit::rxx(const double theta, const uint_t qubit1, const uint_t q
 
 void QuantumCircuit::rxx(const Parameter& theta, const uint_t qubit1, const uint_t qubit2)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_rzz(rust_circuit_.get(), theta.expr_, qubit1, qubit2);
@@ -635,7 +635,7 @@ void QuantumCircuit::ryy(const double theta, const uint_t qubit1, const uint_t q
 
 void QuantumCircuit::ryy(const Parameter& theta, const uint_t qubit1, const uint_t qubit2)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_rzz(rust_circuit_.get(), theta.expr_, qubit1, qubit2);
@@ -650,7 +650,7 @@ void QuantumCircuit::rzz(const double theta, const uint_t qubit1, const uint_t q
 
 void QuantumCircuit::rzz(const Parameter& theta, const uint_t qubit1, const uint_t qubit2)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_rzz(rust_circuit_.get(), theta.expr_, qubit1, qubit2);
@@ -665,7 +665,7 @@ void QuantumCircuit::rzx(const double theta, const uint_t qubit1, const uint_t q
 
 void QuantumCircuit::rzx(const Parameter& theta, const uint_t qubit1, const uint_t qubit2)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
   pre_add_gate();
   //TO DO support parameter expression
   //qc_rzz(rust_circuit_.get(), theta.expr_, qubit1, qubit2);
@@ -681,7 +681,7 @@ void QuantumCircuit::xx_minus_yy(const double theta, const double beta, const ui
 
 void QuantumCircuit::xx_minus_yy(const Parameter &theta, const Parameter &beta, const uint_t qubit1, const uint_t qubit2)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
   pre_add_gate();
   //TO DO support parameter expression
 }
@@ -696,7 +696,7 @@ void QuantumCircuit::xx_plus_yy(const double theta, const double beta, const uin
 
 void QuantumCircuit::xx_plus_yy(const Parameter &theta, const Parameter &beta, const uint_t qubit1, const uint_t qubit2)
 {
-  std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
+  //std::uint32_t qubits[] = {(std::uint32_t)qubit1, (std::uint32_t)qubit2};
   pre_add_gate();
   //TO DO support parameter expression
 }
@@ -813,7 +813,7 @@ IfElseOp& QuantumCircuit::if_test(const std::uint32_t clbit, const std::uint32_t
 {
   pre_add_gate();
 
-  auto op = std::make_shared<IfElseOp>(*this, clbit, value);
+  auto op = std::shared_ptr<IfElseOp>(new IfElseOp(*this, clbit, value));
   pending_control_flow_op_ = op;
 
   body(op->true_body());

--- a/src/primitives/backend_sampler_job.hpp
+++ b/src/primitives/backend_sampler_job.hpp
@@ -100,7 +100,7 @@ public:
         return backend_.stop_job(job_id_);
     }
 
-    PrimitiveResult result(void)
+    PrimitiveResult result(void) override
     {
         return backend_.result(job_id_);
     }

--- a/src/providers/qrmi_backend.hpp
+++ b/src/providers/qrmi_backend.hpp
@@ -157,7 +157,7 @@ public:
     /// @brief Attempt to cancel the job.
     /// @param job_id job id to be cancelled
     /// @return true if the job is cancelled
-    primitives::PrimitiveResult result(std::string& job_id)
+    primitives::PrimitiveResult result(std::string& job_id) override
     {
         primitives::PrimitiveResult ret;
         QrmiTaskStatus status;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is fix for older compilers

### Details and comments

Fixed compiler errors for older compilers, now Qiskit C++ requires at least C++11.


