### PR TITLE
Make Qiskit C++ C++11 compatible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 
 project("qiskit-cpp" LANGUAGES CXX C)
 

--- a/src/circuit/classical/expr.hpp
+++ b/src/circuit/classical/expr.hpp
@@ -19,28 +19,30 @@
 
 #include "circuit/classicalregister.hpp"
 
-
-namespace Qiskit {
-namespace circuit {
+namespace Qiskit
+{
+namespace circuit
+{
 
 // operation types
-enum class OpType {
-  NONE,
-  BIT_NOT,
-  LOGIC_NOT,
-  BIT_AND,
-  BIT_OR,
-  BIT_XOR,
-  LOGIC_AND,
-  LOGIC_OR,
-  EQUAL,
-  NOT_EQUAL,
-  LESS,
-  LESS_EQUAL,
-  GREATER,
-  GREATER_EQUAL,
-  SHIFT_LEFT,
-  SHIFT_RIGHT,
+enum class OpType
+{
+    NONE,
+    BIT_NOT,
+    LOGIC_NOT,
+    BIT_AND,
+    BIT_OR,
+    BIT_XOR,
+    LOGIC_AND,
+    LOGIC_OR,
+    EQUAL,
+    NOT_EQUAL,
+    LESS,
+    LESS_EQUAL,
+    GREATER,
+    GREATER_EQUAL,
+    SHIFT_LEFT,
+    SHIFT_RIGHT,
 };
 
 // ==================================
@@ -51,56 +53,54 @@ enum class OpType {
 class Expr
 {
 protected:
-
 public:
-  Expr() {}
+    Expr() {}
 
-  // operator overloads
-  Unary operator!(void);
+    // operator overloads
+    Unary operator!(void);
 
-  Binary operator==(uint_t right);
-  Binary operator!=(uint_t right);
-  Binary operator<(uint_t right);
-  Binary operator<=(uint_t right);
-  Binary operator>(uint_t right);
-  Binary operator>=(uint_t right);
+    Binary operator==(uint_t right);
+    Binary operator!=(uint_t right);
+    Binary operator<(uint_t right);
+    Binary operator<=(uint_t right);
+    Binary operator>(uint_t right);
+    Binary operator>=(uint_t right);
 
-  Binary operator==(ClassicalRegister& right);
-  Binary operator!=(ClassicalRegister& right);
-  Binary operator<=(ClassicalRegister& right);
-  Binary operator<(ClassicalRegister& right);
-  Binary operator>=(ClassicalRegister& right);
-  Binary operator>(ClassicalRegister& right);
+    Binary operator==(ClassicalRegister &right);
+    Binary operator!=(ClassicalRegister &right);
+    Binary operator<=(ClassicalRegister &right);
+    Binary operator<(ClassicalRegister &right);
+    Binary operator>=(ClassicalRegister &right);
+    Binary operator>(ClassicalRegister &right);
 
-  Binary operator==(Expr& right);
-  Binary operator!=(Expr& right);
-  Binary operator<=(Expr& right);
-  Binary operator<(Expr& right);
-  Binary operator>=(Expr& right);
-  Binary operator>(Expr& right);
+    Binary operator==(Expr &right);
+    Binary operator!=(Expr &right);
+    Binary operator<=(Expr &right);
+    Binary operator<(Expr &right);
+    Binary operator>=(Expr &right);
+    Binary operator>(Expr &right);
 
-  Binary operator||(Expr& right);
-  Binary operator&&(Expr& right);
+    Binary operator||(Expr &right);
+    Binary operator&&(Expr &right);
 
-  virtual std::string type(void)
-  {
-    return std::string("expr");
-  }
-  virtual uint_t value(void)
-  {
-    return 0;
-  }
-  virtual ClassicalRegister creg(void)
-  {
-    ClassicalRegister cr(0, "dummy");
-    return cr;
-  }
-  virtual OpType Op(void)
-  {
-    return OpType::NONE;
-  }
+    virtual std::string type(void)
+    {
+        return std::string("expr");
+    }
+    virtual uint_t value(void)
+    {
+        return 0;
+    }
+    virtual ClassicalRegister creg(void)
+    {
+        ClassicalRegister cr(0, "dummy");
+        return cr;
+    }
+    virtual OpType Op(void)
+    {
+        return OpType::NONE;
+    }
 };
-
 
 // ==================================
 // variables
@@ -110,38 +110,38 @@ public:
 class Var : public Expr
 {
 protected:
-  ClassicalRegister register_;
+    ClassicalRegister register_;
+
 public:
-  /// @brief Create a new classical variable
-  Var() {}
+    /// @brief Create a new classical variable
+    Var() {}
 
-  /// @brief Create a new classical variable
-  /// @param (bit)
-  Var(Clbit& bit)
-  {
-    register_.make_one_bit_register(bit);
-  }
-  /// @brief Create a new classical variable
-  /// @param (cr)
-  Var(ClassicalRegister& cr) : register_(cr) {}
+    /// @brief Create a new classical variable
+    /// @param (bit)
+    Var(Clbit &bit)
+    {
+        register_.make_one_bit_register(bit);
+    }
+    /// @brief Create a new classical variable
+    /// @param (cr)
+    Var(ClassicalRegister &cr) : register_(cr) {}
 
-  /// @brief Create a new classical variable as a copy of var
-  /// @param (var) copy source
-  Var(const Var& var)
-  {
-    register_ = var.register_;
-  }
+    /// @brief Create a new classical variable as a copy of var
+    /// @param (var) copy source
+    Var(const Var &var)
+    {
+        register_ = var.register_;
+    }
 
-  /// @brief Return the type string ("var")
-  std::string type(void) override
-  {
-    return std::string("var");
-  }
-  ClassicalRegister creg(void) override
-  {
-    return register_;
-  }
-
+    /// @brief Return the type string ("var")
+    std::string type(void) override
+    {
+        return std::string("var");
+    }
+    ClassicalRegister creg(void) override
+    {
+        return register_;
+    }
 };
 
 // ==================================
@@ -152,34 +152,34 @@ public:
 class Value : public Expr
 {
 protected:
-  uint_t value_;
+    uint_t value_;
+
 public:
-  /// @brief Create a new single scalar value
-  Value() { value_ = 0; }
+    /// @brief Create a new single scalar value
+    Value() { value_ = 0; }
 
-  /// @brief Create a new single scalar value
-  /// @param (v) scalar value
-  Value(uint_t v)
-  {
-    value_ = v;
-  }
-  /// @brief Create a new single scalar value as a copy of val
-  /// @param (v) copy source
-  Value(const Value& val)
-  {
-    value_ = val.value_;
-  }
+    /// @brief Create a new single scalar value
+    /// @param (v) scalar value
+    Value(uint_t v)
+    {
+        value_ = v;
+    }
+    /// @brief Create a new single scalar value as a copy of val
+    /// @param (v) copy source
+    Value(const Value &val)
+    {
+        value_ = val.value_;
+    }
 
-  /// @brief Return the type string ("value)
-  std::string type(void) override
-  {
-    return std::string("value");
-  }
-  uint_t value(void) override
-  {
-    return value_;
-  }
-
+    /// @brief Return the type string ("value)
+    std::string type(void) override
+    {
+        return std::string("value");
+    }
+    uint_t value(void) override
+    {
+        return value_;
+    }
 };
 
 // ==================================
@@ -190,34 +190,37 @@ public:
 class Unary : public Expr
 {
 public:
-  enum Op {
-  };
+    enum Op
+    {
+    };
+
 protected:
-  Expr& operand_;
-  OpType op_;
+    Expr &operand_;
+    OpType op_;
+
 public:
-  /// @brief Create a new unary expression
-  /// @param (op) The opcode describing which operation is being done
-  /// @param (operand) The operand of the operation
-  Unary(OpType op, Expr& operand) : op_(op), operand_(operand) {}
+    /// @brief Create a new unary expression
+    /// @param (op) The opcode describing which operation is being done
+    /// @param (operand) The operand of the operation
+    Unary(OpType op, Expr &operand) : op_(op), operand_(operand) {}
 
-  /// @brief Create a new unary expression as a copy of src
-  /// @param (src) copy source
-  Unary(const Unary& src) : operand_(src.operand_)
-  {
-    op_ = src.op_;
-  }
+    /// @brief Create a new unary expression as a copy of src
+    /// @param (src) copy source
+    Unary(const Unary &src) : operand_(src.operand_)
+    {
+        op_ = src.op_;
+    }
 
-  /// @brief Return the type string ("unary)
-  std::string type(void) override
-  {
-    return std::string("unary");
-  }
+    /// @brief Return the type string ("unary)
+    std::string type(void) override
+    {
+        return std::string("unary");
+    }
 
-  OpType Op(void) override
-  {
-    return op_;
-  }
+    OpType Op(void) override
+    {
+        return op_;
+    }
 };
 
 // ==================================
@@ -228,289 +231,282 @@ public:
 class Binary : public Expr
 {
 protected:
-  Expr& left_;
-  Expr& right_;
-  OpType op_;
+    Expr &left_;
+    Expr &right_;
+    OpType op_;
+
 public:
-  /// @brief Create a new binary expression
-  /// @param (op) The opcode describing which operation is being done
-  /// @param (left) The left-hand operand
-  /// @param (right) The right-hand operand
-  Binary(OpType op, Expr& left, Expr& right) : op_(op), left_(left), right_(right) {}
+    /// @brief Create a new binary expression
+    /// @param (op) The opcode describing which operation is being done
+    /// @param (left) The left-hand operand
+    /// @param (right) The right-hand operand
+    Binary(OpType op, Expr &left, Expr &right) : op_(op), left_(left), right_(right) {}
 
-  /// @brief Create a new binary expression as a copy of src
-  /// @param (src) copy source
-  Binary(const Binary& src) : left_(src.left_), right_(src.right_)
-  {
-    op_ = src.op_;
-  }
+    /// @brief Create a new binary expression as a copy of src
+    /// @param (src) copy source
+    Binary(const Binary &src) : left_(src.left_), right_(src.right_)
+    {
+        op_ = src.op_;
+    }
 
-  /// @brief Return the type string ("binary")
-  std::string type(void) override
-  {
-    return std::string("binary");
-  }
-  OpType Op(void) override
-  {
-    return op_;
-  }
+    /// @brief Return the type string ("binary")
+    std::string type(void) override
+    {
+        return std::string("binary");
+    }
+    OpType Op(void) override
+    {
+        return op_;
+    }
 };
-
-
 
 // ==================================
 // implementations of expressions
 // ==================================
 Unary Expr::operator!(void)
 {
-  return Unary(OpType::LOGIC_NOT, *this);
+    return Unary(OpType::LOGIC_NOT, *this);
 }
 
 Binary Expr::operator==(uint_t right)
 {
-  Value r(right);
-  return Binary(OpType::EQUAL, *this, r);
+    Value r(right);
+    return Binary(OpType::EQUAL, *this, r);
 }
 
 Binary Expr::operator!=(uint_t right)
 {
-  Value r(right);
-  return Binary(OpType::NOT_EQUAL, *this, r);
+    Value r(right);
+    return Binary(OpType::NOT_EQUAL, *this, r);
 }
 
 Binary Expr::operator<(uint_t right)
 {
-  Value r(right);
-  return Binary(OpType::LESS, *this, r);
+    Value r(right);
+    return Binary(OpType::LESS, *this, r);
 }
 
 Binary Expr::operator<=(uint_t right)
 {
-  Value r(right);
-  return Binary(OpType::LESS_EQUAL, *this, r);
+    Value r(right);
+    return Binary(OpType::LESS_EQUAL, *this, r);
 }
 
 Binary Expr::operator>(uint_t right)
 {
-  Value r(right);
-  return Binary(OpType::GREATER, *this, r);
+    Value r(right);
+    return Binary(OpType::GREATER, *this, r);
 }
 
 Binary Expr::operator>=(uint_t right)
 {
-  Value r(right);
-  return Binary(OpType::GREATER_EQUAL, *this, r);
+    Value r(right);
+    return Binary(OpType::GREATER_EQUAL, *this, r);
 }
 
-Binary Expr::operator==(ClassicalRegister& right)
+Binary Expr::operator==(ClassicalRegister &right)
 {
-  Var r(right);
-  return Binary(OpType::EQUAL, *this, r);
+    Var r(right);
+    return Binary(OpType::EQUAL, *this, r);
 }
 
-Binary Expr::operator!=(ClassicalRegister& right)
+Binary Expr::operator!=(ClassicalRegister &right)
 {
-  Var r(right);
-  return Binary(OpType::NOT_EQUAL, *this, r);
+    Var r(right);
+    return Binary(OpType::NOT_EQUAL, *this, r);
 }
 
-Binary Expr::operator<(ClassicalRegister& right)
+Binary Expr::operator<(ClassicalRegister &right)
 {
-  Var r(right);
-  return Binary(OpType::LESS, *this, r);
+    Var r(right);
+    return Binary(OpType::LESS, *this, r);
 }
 
-Binary Expr::operator<=(ClassicalRegister& right)
+Binary Expr::operator<=(ClassicalRegister &right)
 {
-  Var r(right);
-  return Binary(OpType::LESS_EQUAL, *this, r);
+    Var r(right);
+    return Binary(OpType::LESS_EQUAL, *this, r);
 }
 
-Binary Expr::operator>(ClassicalRegister& right)
+Binary Expr::operator>(ClassicalRegister &right)
 {
-  Var r(right);
-  return Binary(OpType::GREATER, *this, r);
+    Var r(right);
+    return Binary(OpType::GREATER, *this, r);
 }
 
-Binary Expr::operator>=(ClassicalRegister& right)
+Binary Expr::operator>=(ClassicalRegister &right)
 {
-  Var r(right);
-  return Binary(OpType::GREATER_EQUAL, *this, r);
+    Var r(right);
+    return Binary(OpType::GREATER_EQUAL, *this, r);
 }
 
-Binary Expr::operator==(Expr& r)
+Binary Expr::operator==(Expr &r)
 {
-  return Binary(OpType::EQUAL, *this, r);
+    return Binary(OpType::EQUAL, *this, r);
 }
 
-Binary Expr::operator!=(Expr& r)
+Binary Expr::operator!=(Expr &r)
 {
-  return Binary(OpType::NOT_EQUAL, *this, r);
+    return Binary(OpType::NOT_EQUAL, *this, r);
 }
 
-Binary Expr::operator<(Expr& r)
+Binary Expr::operator<(Expr &r)
 {
-  return Binary(OpType::LESS, *this, r);
+    return Binary(OpType::LESS, *this, r);
 }
 
-Binary Expr::operator<=(Expr& r)
+Binary Expr::operator<=(Expr &r)
 {
-  return Binary(OpType::LESS_EQUAL, *this, r);
+    return Binary(OpType::LESS_EQUAL, *this, r);
 }
 
-Binary Expr::operator>(Expr& r)
+Binary Expr::operator>(Expr &r)
 {
-  return Binary(OpType::GREATER, *this, r);
+    return Binary(OpType::GREATER, *this, r);
 }
 
-Binary Expr::operator>=(Expr& r)
+Binary Expr::operator>=(Expr &r)
 {
-  return Binary(OpType::GREATER_EQUAL, *this, r);
+    return Binary(OpType::GREATER_EQUAL, *this, r);
 }
 
-Binary Expr::operator&&(Expr& r)
+Binary Expr::operator&&(Expr &r)
 {
-  return Binary(OpType::LOGIC_AND, *this, r);
+    return Binary(OpType::LOGIC_AND, *this, r);
 }
 
-Binary Expr::operator||(Expr& r)
+Binary Expr::operator||(Expr &r)
 {
-  return Binary(OpType::LOGIC_OR, *this, r);
+    return Binary(OpType::LOGIC_OR, *this, r);
 }
 
 Unary ClassicalRegister::operator!(void)
 {
-  Var v(*this);
-  return Unary(OpType::LOGIC_NOT, v);
+    Var v(*this);
+    return Unary(OpType::LOGIC_NOT, v);
 }
 
-Binary ClassicalRegister::operator==(ClassicalRegister& right)
+Binary ClassicalRegister::operator==(ClassicalRegister &right)
 {
-  Var v(*this);
-  Var r(right);
-  return Binary(OpType::EQUAL, v, r);
+    Var v(*this);
+    Var r(right);
+    return Binary(OpType::EQUAL, v, r);
 }
 
-Binary ClassicalRegister::operator!=(ClassicalRegister& right)
+Binary ClassicalRegister::operator!=(ClassicalRegister &right)
 {
-  Var v(*this);
-  Var r(right);
-  return Binary(OpType::NOT_EQUAL, v, r);
+    Var v(*this);
+    Var r(right);
+    return Binary(OpType::NOT_EQUAL, v, r);
 }
 
-Binary ClassicalRegister::operator<(ClassicalRegister& right)
+Binary ClassicalRegister::operator<(ClassicalRegister &right)
 {
-  Var v(*this);
-  Var r(right);
-  return Binary(OpType::LESS, v, r);
+    Var v(*this);
+    Var r(right);
+    return Binary(OpType::LESS, v, r);
 }
 
-Binary ClassicalRegister::operator<=(ClassicalRegister& right)
+Binary ClassicalRegister::operator<=(ClassicalRegister &right)
 {
-  Var v(*this);
-  Var r(right);
-  return Binary(OpType::LESS_EQUAL, v, r);
+    Var v(*this);
+    Var r(right);
+    return Binary(OpType::LESS_EQUAL, v, r);
 }
 
-Binary ClassicalRegister::operator>(ClassicalRegister& right)
+Binary ClassicalRegister::operator>(ClassicalRegister &right)
 {
-  Var v(*this);
-  Var r(right);
-  return Binary(OpType::GREATER, v, r);
+    Var v(*this);
+    Var r(right);
+    return Binary(OpType::GREATER, v, r);
 }
 
-Binary ClassicalRegister::operator>=(ClassicalRegister& right)
+Binary ClassicalRegister::operator>=(ClassicalRegister &right)
 {
-  Var v(*this);
-  Var r(right);
-  return Binary(OpType::GREATER_EQUAL, v, r);
+    Var v(*this);
+    Var r(right);
+    return Binary(OpType::GREATER_EQUAL, v, r);
 }
 
 Binary ClassicalRegister::operator==(uint_t right)
 {
-  Var v(*this);
-  Value r(right);
-  return Binary(OpType::EQUAL, v, r);
+    Var v(*this);
+    Value r(right);
+    return Binary(OpType::EQUAL, v, r);
 }
 
 Binary ClassicalRegister::operator!=(uint_t right)
 {
-  Var v(*this);
-  Value r(right);
-  return Binary(OpType::NOT_EQUAL, v, r);
+    Var v(*this);
+    Value r(right);
+    return Binary(OpType::NOT_EQUAL, v, r);
 }
 
 Binary ClassicalRegister::operator<(uint_t right)
 {
-  Var v(*this);
-  Value r(right);
-  return Binary(OpType::LESS, v, r);
+    Var v(*this);
+    Value r(right);
+    return Binary(OpType::LESS, v, r);
 }
 
 Binary ClassicalRegister::operator<=(uint_t right)
 {
-  Var v(*this);
-  Value r(right);
-  return Binary(OpType::LESS_EQUAL, v, r);
+    Var v(*this);
+    Value r(right);
+    return Binary(OpType::LESS_EQUAL, v, r);
 }
 
 Binary ClassicalRegister::operator>(uint_t right)
 {
-  Var v(*this);
-  Value r(right);
-  return Binary(OpType::GREATER, v, r);
+    Var v(*this);
+    Value r(right);
+    return Binary(OpType::GREATER, v, r);
 }
 
 Binary ClassicalRegister::operator>=(uint_t right)
 {
-  Var v(*this);
-  Value r(right);
-  return Binary(OpType::GREATER_EQUAL, v, r);
+    Var v(*this);
+    Value r(right);
+    return Binary(OpType::GREATER_EQUAL, v, r);
 }
 
-Binary ClassicalRegister::operator==(Expr& right)
+Binary ClassicalRegister::operator==(Expr &right)
 {
-  Var v(*this);
-  return Binary(OpType::EQUAL, v, right);
+    Var v(*this);
+    return Binary(OpType::EQUAL, v, right);
 }
 
-Binary ClassicalRegister::operator!=(Expr& right)
+Binary ClassicalRegister::operator!=(Expr &right)
 {
-  Var v(*this);
-  return Binary(OpType::NOT_EQUAL, v, right);
+    Var v(*this);
+    return Binary(OpType::NOT_EQUAL, v, right);
 }
 
-Binary ClassicalRegister::operator<(Expr& right)
+Binary ClassicalRegister::operator<(Expr &right)
 {
-  Var v(*this);
-  return Binary(OpType::LESS, v, right);
+    Var v(*this);
+    return Binary(OpType::LESS, v, right);
 }
 
-Binary ClassicalRegister::operator<=(Expr& right)
+Binary ClassicalRegister::operator<=(Expr &right)
 {
-  Var v(*this);
-  return Binary(OpType::LESS_EQUAL, v, right);
+    Var v(*this);
+    return Binary(OpType::LESS_EQUAL, v, right);
 }
 
-Binary ClassicalRegister::operator>(Expr& right)
+Binary ClassicalRegister::operator>(Expr &right)
 {
-  Var v(*this);
-  return Binary(OpType::GREATER, v, right);
+    Var v(*this);
+    return Binary(OpType::GREATER, v, right);
 }
 
-Binary ClassicalRegister::operator>=(Expr& right)
+Binary ClassicalRegister::operator>=(Expr &right)
 {
-  Var v(*this);
-  return Binary(OpType::GREATER_EQUAL, v, right);
+    Var v(*this);
+    return Binary(OpType::GREATER_EQUAL, v, right);
 }
-
-
-
-
-
 
 } // namespace circuit
 } // namespace Qiskit
 
-#endif  // __qiskitcpp_circuit_classical_expr_hpp__
-
+#endif // __qiskitcpp_circuit_classical_expr_hpp__

--- a/src/circuit/classicalregister.hpp
+++ b/src/circuit/classicalregister.hpp
@@ -20,8 +20,10 @@
 #include "circuit/register.hpp"
 #include "qiskit.h"
 
-namespace Qiskit {
-namespace circuit {
+namespace Qiskit
+{
+namespace circuit
+{
 
 class Expr;
 class Unary;
@@ -35,82 +37,87 @@ class Binary;
 class ClassicalRegister : public Register
 {
 protected:
-  std::shared_ptr<QkClassicalRegister> rust_register_ = nullptr;
-  static uint_t instances_counter_;
+    std::shared_ptr<QkClassicalRegister> rust_register_ = nullptr;
+    static uint_t instances_counter_;
+
 public:
-  /// @brief Create a new ClassicalRegister
-  ClassicalRegister()
-  {
-    size_ = 0;
-    name_ = prefix();
-    rust_register_ = nullptr;
-  }
-  /// @brief Create a new ClassicalRegister
-  /// @param (size) The number of bits to include in the register
-  ClassicalRegister(uint_t size) : Register(size)
-  {
-    name_ = prefix();
-    std::shared_ptr<QkClassicalRegister> reg(qk_classical_register_new((std::uint32_t)size, (const char*)name_.c_str()), qk_classical_register_free);
-    rust_register_ = reg;
-  }
-
-  /// @brief Create a new ClassicalRegister
-  /// @param (size) The number of bits to include in the register
-  /// @param (name) The name of the register. If not provided, a unique name will be auto-generated from the register type.
-  ClassicalRegister(uint_t size, std::string name) : Register(size, name) {
-    std::shared_ptr<QkClassicalRegister> reg(qk_classical_register_new((std::uint32_t)size, (const char*)name.c_str()), qk_classical_register_free);
-    rust_register_ = reg;
-  }
-
-  /// @brief Create a new ClassicalRegister as a copy of reg.
-  /// @param (reg) copy source
-  ClassicalRegister(const ClassicalRegister& reg) : Register(reg) {
-    rust_register_ = reg.rust_register_;
-  }
-
-  /// @brief Prefix of the register name
-  /// @return prefix
-  std::string prefix(void) override
-  {
-    std::string ret = "c";
-    ret += std::to_string(instances_counter_++);
-    return ret;
-  }
-
-  ~ClassicalRegister() {
-    if (rust_register_) {
-      rust_register_.reset();
+    /// @brief Create a new ClassicalRegister
+    ClassicalRegister()
+    {
+        size_ = 0;
+        name_ = prefix();
+        rust_register_ = nullptr;
     }
-  }
+    /// @brief Create a new ClassicalRegister
+    /// @param (size) The number of bits to include in the register
+    ClassicalRegister(uint_t size) : Register(size)
+    {
+        name_ = prefix();
+        std::shared_ptr<QkClassicalRegister> reg(qk_classical_register_new((std::uint32_t)size, (const char *)name_.c_str()), qk_classical_register_free);
+        rust_register_ = reg;
+    }
 
-  const std::shared_ptr<QkClassicalRegister>& get_register() const {
-    return rust_register_;
-  }
+    /// @brief Create a new ClassicalRegister
+    /// @param (size) The number of bits to include in the register
+    /// @param (name) The name of the register. If not provided, a unique name will be auto-generated from the register type.
+    ClassicalRegister(uint_t size, std::string name) : Register(size, name)
+    {
+        std::shared_ptr<QkClassicalRegister> reg(qk_classical_register_new((std::uint32_t)size, (const char *)name.c_str()), qk_classical_register_free);
+        rust_register_ = reg;
+    }
 
-  // operator overloads for classical expressions
-  Unary operator!(void);
+    /// @brief Create a new ClassicalRegister as a copy of reg.
+    /// @param (reg) copy source
+    ClassicalRegister(const ClassicalRegister &reg) : Register(reg)
+    {
+        rust_register_ = reg.rust_register_;
+    }
 
-  Binary operator==(ClassicalRegister& right);
-  Binary operator!=(ClassicalRegister& right);
-  Binary operator<(ClassicalRegister& right);
-  Binary operator<=(ClassicalRegister& right);
-  Binary operator>(ClassicalRegister& right);
-  Binary operator>=(ClassicalRegister& right);
+    /// @brief Prefix of the register name
+    /// @return prefix
+    std::string prefix(void) override
+    {
+        std::string ret = "c";
+        ret += std::to_string(instances_counter_++);
+        return ret;
+    }
 
-  Binary operator==(uint_t right);
-  Binary operator!=(uint_t right);
-  Binary operator<(uint_t right);
-  Binary operator<=(uint_t right);
-  Binary operator>(uint_t right);
-  Binary operator>=(uint_t right);
+    ~ClassicalRegister()
+    {
+        if (rust_register_)
+        {
+            rust_register_.reset();
+        }
+    }
 
-  Binary operator==(Expr& right);
-  Binary operator!=(Expr& right);
-  Binary operator<(Expr& right);
-  Binary operator<=(Expr& right);
-  Binary operator>(Expr& right);
-  Binary operator>=(Expr& right);
+    const std::shared_ptr<QkClassicalRegister> &get_register() const
+    {
+        return rust_register_;
+    }
 
+    // operator overloads for classical expressions
+    Unary operator!(void);
+
+    Binary operator==(ClassicalRegister &right);
+    Binary operator!=(ClassicalRegister &right);
+    Binary operator<(ClassicalRegister &right);
+    Binary operator<=(ClassicalRegister &right);
+    Binary operator>(ClassicalRegister &right);
+    Binary operator>=(ClassicalRegister &right);
+
+    Binary operator==(uint_t right);
+    Binary operator!=(uint_t right);
+    Binary operator<(uint_t right);
+    Binary operator<=(uint_t right);
+    Binary operator>(uint_t right);
+    Binary operator>=(uint_t right);
+
+    Binary operator==(Expr &right);
+    Binary operator!=(Expr &right);
+    Binary operator<(Expr &right);
+    Binary operator<=(Expr &right);
+    Binary operator>(Expr &right);
+    Binary operator>=(Expr &right);
 };
 
 uint_t ClassicalRegister::instances_counter_ = 0;
@@ -118,5 +125,4 @@ uint_t ClassicalRegister::instances_counter_ = 0;
 } // namespace circuit
 } // namespace Qiskit
 
-#endif  // __qiskitcpp_circuit_classical_register_hpp__
-
+#endif // __qiskitcpp_circuit_classical_register_hpp__

--- a/src/circuit/library/quantum_volume.hpp
+++ b/src/circuit/library/quantum_volume.hpp
@@ -14,7 +14,6 @@
 
 // Quantum Volume circuit
 
-
 #ifndef __qiskitcpp_circuit_library_quantum_volume_hpp__
 #define __qiskitcpp_circuit_library_quantum_volume_hpp__
 
@@ -23,114 +22,128 @@
 #include "circuit/quantumcircuit.hpp"
 #include "utils/rng.hpp"
 
-
-namespace Qiskit {
-namespace circuit {
+namespace Qiskit
+{
+namespace circuit
+{
 
 /// @class QuantumVolume
 /// @brief A quantum volume model circuit.
-class QuantumVolume : public QuantumCircuit {
+class QuantumVolume : public QuantumCircuit
+{
 public:
-  /// @brief Create a new QuantumVolume
-  /// @param (num_qubits) number of active qubits in the model circuit
-  /// @param (depth) layers of SU(4) operations in model circuit
-  /// @param (seed) random number generator or generator seed
-  /// @param (classical) use classical permutations at every layer, rather than quantum.
-  QuantumVolume(uint_t num_qubits, uint_t depth = 0, uint_t seed = 0, bool classical = true);
+    /// @brief Create a new QuantumVolume
+    /// @param (num_qubits) number of active qubits in the model circuit
+    /// @param (depth) layers of SU(4) operations in model circuit
+    /// @param (seed) random number generator or generator seed
+    /// @param (classical) use classical permutations at every layer, rather than quantum.
+    QuantumVolume(uint_t num_qubits, uint_t depth = 0, uint_t seed = 0, bool classical = true);
 
 protected:
-  void make_random_unitary_matrix(std::vector<complex_t>& matrix, uint_t size, RngEngine& rng);
+    void make_random_unitary_matrix(std::vector<complex_t> &matrix, uint_t size, RngEngine &rng);
 };
 
 QuantumVolume::QuantumVolume(uint_t num_qubits, uint_t depth, uint_t seed, bool classical) : QuantumCircuit(num_qubits, num_qubits, 0.0)
 {
-  std::vector<complex_t> unitary;
-  RngEngine rng;
-  if (seed == 0)
-    rng.set_random_seed();
-  else
-    rng.set_seed(seed);
-  if(depth == 0)
-    depth = num_qubits;
-  uint_t width = num_qubits / 2;
-  uint_t size = width * depth;
+    std::vector<complex_t> unitary;
+    RngEngine rng;
+    if (seed == 0)
+        rng.set_random_seed();
+    else
+        rng.set_seed(seed);
+    if (depth == 0)
+        depth = num_qubits;
+    uint_t width = num_qubits / 2;
+    uint_t size = width * depth;
 
-  make_random_unitary_matrix(unitary, size, rng);
-  reg_t perm = rng.permutation(num_qubits);
-  if(classical) {
-    for (int_t i = 0; i < depth; i++) {
-      for (int_t j = 0; j < width; j++) {
-        std::vector<complex_t> mat(16);
-        for (int_t k = 0; k < 16; k++) {
-          mat[k] = unitary[(i*width + j)*16 + k];
+    make_random_unitary_matrix(unitary, size, rng);
+    reg_t perm = rng.permutation(num_qubits);
+    if (classical)
+    {
+        for (uint_t i = 0; i < depth; i++)
+        {
+            for (uint_t j = 0; j < width; j++)
+            {
+                std::vector<complex_t> mat(16);
+                for (uint_t k = 0; k < 16; k++)
+                {
+                    mat[k] = unitary[(i * width + j) * 16 + k];
+                }
+                reg_t bits = {perm[j * 2], perm[j * 2 + 1]};
+                QuantumCircuit::unitary(mat, bits);
+            }
         }
-        reg_t bits = {perm[j * 2], perm[j * 2 + 1]};
-        QuantumCircuit::unitary(mat, bits);
-      }
     }
-  }
-  else {
-    // implement using swap gates
-  }
+    else
+    {
+        // implement using swap gates
+    }
 }
 
-void QuantumVolume::make_random_unitary_matrix(std::vector<complex_t>& matrix, uint_t size, RngEngine& rng)
+void QuantumVolume::make_random_unitary_matrix(std::vector<complex_t> &matrix, uint_t size, RngEngine &rng)
 {
-  const double rsq2 = 1.0 / sqrt(2.0);
-  matrix.resize(size*4*4);
-  // real
-  for (int_t i = 0; i < size*4*4; i++) {
-    matrix[i] = rng.normal();
-  }
-  // imag
-  for (int_t i = 0; i < size*4*4; i++) {
-    matrix[i] = complex_t(matrix[i].real(), rng.normal());
-  }
+    const double rsq2 = 1.0 / sqrt(2.0);
+    matrix.resize(size * 4 * 4);
+    // real
+    for (uint_t i = 0; i < size * 4 * 4; i++)
+    {
+        matrix[i] = rng.normal();
+    }
+    // imag
+    for (uint_t i = 0; i < size * 4 * 4; i++)
+    {
+        matrix[i] = complex_t(matrix[i].real(), rng.normal());
+    }
 
-  // QR factorization to make unitary matrix
-  for (int_t i = 0; i < size; i++) {
-    complex_t Q[4][4];
-    complex_t A[4][4];
-    // R is not used for random unitary
-    for (int_t j=0;j<4;j++){
-      for (int_t k=0;k<4;k++){
-        A[j][k] = rsq2 * matrix[i*4*4 + j*4 + k];
-      	Q[j][k] = 0.0;
-      }
-    }
-    double r = 0.0;
-    for(int_t j=0;j<4;j++)
-      r += A[j][0].real() * A[j][0].real() + A[j][0].imag() * A[j][0].imag();
-    r = sqrt(r);
-    for(int_t j=0;j<4;j++)
-      Q[j][0] = A[j][0] / r;
+    // QR factorization to make unitary matrix
+    for (uint_t i = 0; i < size; i++)
+    {
+        complex_t Q[4][4];
+        complex_t A[4][4];
+        // R is not used for random unitary
+        for (int_t j = 0; j < 4; j++)
+        {
+            for (int_t k = 0; k < 4; k++)
+            {
+                A[j][k] = rsq2 * matrix[i * 4 * 4 + j * 4 + k];
+                Q[j][k] = 0.0;
+            }
+        }
+        double r = 0.0;
+        for (int_t j = 0; j < 4; j++)
+            r += A[j][0].real() * A[j][0].real() + A[j][0].imag() * A[j][0].imag();
+        r = sqrt(r);
+        for (int_t j = 0; j < 4; j++)
+            Q[j][0] = A[j][0] / r;
 
-    for(int_t k=1;k<4;k++){
-      for (int_t j=0;j<k;j++){
-        complex_t d = 0.0;
-        for (int_t l=0;l<4;l++)
-	      	d += A[l][k] * std::conj(Q[l][j]);
-        for (int_t l=0;l<4;l++)
-          A[l][k] -= d * Q[l][j];
-      }
-      r = 0.0;
-      for (int_t l=0;l<4;l++)
-        r += A[l][k].real() * A[l][k].real() + A[l][k].imag() * A[l][k].imag();
-      r = sqrt(r);
-      for (int_t l=0;l<4;l++)
-        Q[l][k] = A[l][k] / r;
+        for (int_t k = 1; k < 4; k++)
+        {
+            for (int_t j = 0; j < k; j++)
+            {
+                complex_t d = 0.0;
+                for (int_t l = 0; l < 4; l++)
+                    d += A[l][k] * std::conj(Q[l][j]);
+                for (int_t l = 0; l < 4; l++)
+                    A[l][k] -= d * Q[l][j];
+            }
+            r = 0.0;
+            for (int_t l = 0; l < 4; l++)
+                r += A[l][k].real() * A[l][k].real() + A[l][k].imag() * A[l][k].imag();
+            r = sqrt(r);
+            for (int_t l = 0; l < 4; l++)
+                Q[l][k] = A[l][k] / r;
+        }
+        for (int_t j = 0; j < 4; j++)
+        {
+            for (int_t k = 0; k < 4; k++)
+            {
+                matrix[i * 4 * 4 + j * 4 + k] = Q[j][k];
+            }
+        }
     }
-    for (int_t j=0;j<4;j++){
-      for (int_t k=0;k<4;k++){
-        matrix[i*4*4 + j*4 + k] = Q[j][k];
-      }
-    }
-  }
 }
 
 } // namespace circuit
 } // namespace qiskitcpp
 
-
-
-#endif  //__qiskitcpp_circuit_library_quantum_volume_hpp__
+#endif //__qiskitcpp_circuit_library_quantum_volume_hpp__

--- a/src/circuit/quantumcircuit_impl.hpp
+++ b/src/circuit/quantumcircuit_impl.hpp
@@ -89,7 +89,7 @@ QuantumCircuit::QuantumCircuit(std::vector<QuantumRegister> &qregs, std::vector<
     qregs_.resize(qregs.size());
     cregs_.resize(cregs.size());
 
-    for (int_t i = 0; i < qregs.size(); i++)
+    for (uint_t i = 0; i < qregs.size(); i++)
     {
         qregs_[i] = qregs[i];
         qregs[i][0].get_register()->set_base_index(num_qubits_);
@@ -97,7 +97,7 @@ QuantumCircuit::QuantumCircuit(std::vector<QuantumRegister> &qregs, std::vector<
         num_qubits_ += qregs[i].size();
     }
 
-    for (int_t i = 0; i < cregs.size(); i++)
+    for (uint_t i = 0; i < cregs.size(); i++)
     {
         cregs_[i] = cregs[i];
         cregs[i][0].get_register()->set_base_index(num_clbits_);
@@ -107,11 +107,11 @@ QuantumCircuit::QuantumCircuit(std::vector<QuantumRegister> &qregs, std::vector<
 
     rust_circuit_ = std::shared_ptr<rust_circuit>(qk_circuit_new((std::uint32_t)num_qubits_, (std::uint32_t)num_clbits_), qk_circuit_free);
 
-    for (int_t i = 0; i < qregs_.size(); i++)
+    for (uint_t i = 0; i < qregs_.size(); i++)
     {
         qk_circuit_add_quantum_register(rust_circuit_.get(), qregs_[i].get_register().get());
     }
-    for (int_t i = 0; i < cregs_.size(); i++)
+    for (uint_t i = 0; i < cregs_.size(); i++)
     {
         qk_circuit_add_classical_register(rust_circuit_.get(), cregs_[i].get_register().get());
     }
@@ -220,9 +220,9 @@ void QuantumCircuit::get_qubits(reg_t &bits)
 {
     bits.clear();
     bits.reserve(num_qubits_);
-    for (int_t i = 0; i < qregs_.size(); i++)
+    for (uint_t i = 0; i < qregs_.size(); i++)
     {
-        for (int_t j = 0; j < qregs_[i].size(); j++)
+        for (uint_t j = 0; j < qregs_[i].size(); j++)
         {
             bits.push_back(qregs_[i][j]);
         }
@@ -233,9 +233,9 @@ void QuantumCircuit::get_clbits(reg_t &bits)
 {
     bits.clear();
     bits.reserve(num_clbits_);
-    for (int_t i = 0; i < cregs_.size(); i++)
+    for (uint_t i = 0; i < cregs_.size(); i++)
     {
-        for (int_t j = 0; j < cregs_[i].size(); j++)
+        for (uint_t j = 0; j < cregs_[i].size(); j++)
         {
             bits.push_back(cregs_[i][j]);
         }
@@ -469,7 +469,7 @@ void QuantumCircuit::unitary(const std::vector<complex_t> &unitary, const reg_t 
 {
     pre_add_gate();
     std::vector<std::uint32_t> qubits32(qubits.size());
-    for (int_t i = 0; i < qubits.size(); i++)
+    for (uint_t i = 0; i < qubits.size(); i++)
         qubits32[i] = (std::uint32_t)qubits[i];
 
     qk_circuit_unitary(rust_circuit_.get(), (const QkComplex64 *)unitary.data(), qubits32.data(), (std::uint32_t)qubits.size(), true);
@@ -809,11 +809,11 @@ void QuantumCircuit::measure(const uint_t qubit, const uint_t cbit)
 void QuantumCircuit::measure(QuantumRegister &qreg, ClassicalRegister &creg)
 {
     pre_add_gate();
-    int size = qreg.size();
+    uint_t size = qreg.size();
     if (size > creg.size())
         size = creg.size();
     // TO DO implement multi-bits measure in C-API
-    for (int_t i = 0; i < size; i++)
+    for (uint_t i = 0; i < size; i++)
     {
         qk_circuit_measure(rust_circuit_.get(), (std::uint32_t)qreg[i], (std::uint32_t)creg[i]);
         measure_map_.push_back(std::pair<uint_t, uint_t>(qreg[i], creg[i]));
@@ -830,7 +830,7 @@ void QuantumCircuit::reset(QuantumRegister &qreg)
 {
     pre_add_gate();
     // TO DO implement multi-bits rest in C-API
-    for (int_t i = 0; i < qreg.size(); i++)
+    for (uint_t i = 0; i < qreg.size(); i++)
     {
         qk_circuit_reset(rust_circuit_.get(), (std::uint32_t)qreg[i]);
     }
@@ -847,11 +847,11 @@ void QuantumCircuit::barrier(const reg_t &qubits)
 {
     pre_add_gate();
     std::vector<std::uint32_t> qubits32(qubits.size());
-    for (int_t i = 0; i < qubits.size(); i++)
+    for (uint_t i = 0; i < qubits.size(); i++)
     {
         qubits32[i] = (std::uint32_t)qubits[i];
     }
-    qk_circuit_barrier(rust_circuit_.get(), qubits32.data(), qubits32.size());
+    qk_circuit_barrier(rust_circuit_.get(), qubits32.data(), (uint32_t)qubits32.size());
 }
 
 void QuantumCircuit::add_pending_control_flow_op(void)
@@ -885,7 +885,7 @@ uint_t QuantumCircuit::num_parameters(void) const
 void QuantumCircuit::assign_parameters(const std::vector<std::string> keys, const std::vector<double> values)
 {
     std::vector<char *> c_keys;
-    for (int_t i = 0; i < keys.size(); i++)
+    for (uint_t i = 0; i < keys.size(); i++)
     {
         c_keys.push_back((char *)keys[i].c_str());
     }
@@ -920,12 +920,12 @@ QuantumCircuit QuantumCircuit::operator+(QuantumCircuit &rhs)
         rhs.get_clbits(clbits);
         uint_t size = std::min(qubits.size(), clbits.size());
         std::vector<std::uint32_t> vqubits(size);
-        for (int_t i = 0; i < size; i++)
+        for (uint_t i = 0; i < size; i++)
         {
             vqubits[i] = (std::uint32_t)qubits[i];
         }
         std::vector<std::uint32_t> vclbits(size);
-        for (int_t i = 0; i < size; i++)
+        for (uint_t i = 0; i < size; i++)
         {
             vclbits[i] = (std::uint32_t)clbits[i];
         }
@@ -951,12 +951,12 @@ void QuantumCircuit::compose(QuantumCircuit &circ, const reg_t &qubits, const re
     pre_add_gate();
     uint_t size = std::min(qubits.size(), clbits.size());
     std::vector<std::uint32_t> vqubits(size);
-    for (int_t i = 0; i < size; i++)
+    for (uint_t i = 0; i < size; i++)
     {
         vqubits[i] = (std::uint32_t)qubits[i];
     }
     std::vector<std::uint32_t> vclbits(size);
-    for (int_t i = 0; i < size; i++)
+    for (uint_t i = 0; i < size; i++)
     {
         vclbits[i] = (std::uint32_t)clbits[i];
     }
@@ -972,14 +972,14 @@ void QuantumCircuit::compose(QuantumCircuit &circ, const reg_t &qubits, const re
 
         std::vector<std::uint32_t> vqubits(op->num_qubits);
         std::vector<std::uint32_t> vclbits;
-        for (int j = 0; j < op->num_qubits; j++)
+        for (uint_t j = 0; j < op->num_qubits; j++)
         {
             vqubits[j] = (std::uint32_t)qubits[op->qubits[j]];
         }
         if (op->num_clbits > 0)
         {
             vclbits.resize(op->num_clbits);
-            for (int j = 0; j < op->num_clbits; j++)
+            for (uint_t j = 0; j < op->num_clbits; j++)
             {
                 vclbits[j] = (std::uint32_t)clbits[op->clbits[j]];
             }
@@ -991,7 +991,7 @@ void QuantumCircuit::compose(QuantumCircuit &circ, const reg_t &qubits, const re
         }
         else if (std::string("barrier") == op->name)
         {
-            qk_circuit_barrier(rust_circuit_.get(), vqubits.data(), vqubits.size());
+            qk_circuit_barrier(rust_circuit_.get(), vqubits.data(), (uint32_t)vqubits.size());
         }
         else if (std::string("measure") == op->name)
         {
@@ -1015,7 +1015,7 @@ void QuantumCircuit::append(const Instruction &op, const reg_t &qubits)
     if (op.num_qubits() == qubits.size())
     {
         std::vector<std::uint32_t> vqubits(qubits.size());
-        for (int_t i = 0; i < qubits.size(); i++)
+        for (uint_t i = 0; i < qubits.size(); i++)
         {
             vqubits[i] = (std::uint32_t)qubits[i];
         }
@@ -1035,7 +1035,7 @@ void QuantumCircuit::append(const Instruction &op, const reg_t &qubits)
             }
             else if (std::string("barrier") == op.name())
             {
-                qk_circuit_barrier(rust_circuit_.get(), vqubits.data(), vqubits.size());
+                qk_circuit_barrier(rust_circuit_.get(), vqubits.data(), (uint32_t)vqubits.size());
             }
             else if (std::string("measure") == op.name())
             {
@@ -1066,7 +1066,7 @@ void QuantumCircuit::append(const Instruction &op, const std::vector<std::uint32
             }
             else if (std::string("barrier") == op.name())
             {
-                qk_circuit_barrier(rust_circuit_.get(), qubits.data(), qubits.size());
+                qk_circuit_barrier(rust_circuit_.get(), qubits.data(), (uint32_t)qubits.size());
             }
             else if (std::string("measure") == op.name())
             {
@@ -1080,7 +1080,7 @@ void QuantumCircuit::append(const Instruction &op, const std::vector<std::uint32
 void QuantumCircuit::append(const CircuitInstruction &inst)
 {
     std::vector<std::uint32_t> vqubits(inst.qubits().size());
-    for (int_t i = 0; i < inst.qubits().size(); i++)
+    for (uint_t i = 0; i < inst.qubits().size(); i++)
     {
         vqubits[i] = (std::uint32_t)inst.qubits()[i];
     }
@@ -1100,7 +1100,7 @@ void QuantumCircuit::append(const CircuitInstruction &inst)
         }
         else if (std::string("barrier") == inst.instruction().name())
         {
-            qk_circuit_barrier(rust_circuit_.get(), vqubits.data(), vqubits.size());
+            qk_circuit_barrier(rust_circuit_.get(), vqubits.data(), (uint32_t)vqubits.size());
         }
         else if (std::string("measure") == inst.instruction().name())
         {
@@ -1177,7 +1177,7 @@ void QuantumCircuit::print(void) const
         if (op->num_qubits > 0)
         {
             std::cout << "(";
-            for (int j = 0; j < op->num_qubits; j++)
+            for (uint_t j = 0; j < op->num_qubits; j++)
             {
                 std::cout << op->qubits[j];
                 if (j != op->num_qubits - 1)
@@ -1188,7 +1188,7 @@ void QuantumCircuit::print(void) const
         if (op->num_clbits > 0)
         {
             std::cout << "(";
-            for (int j = 0; j < op->num_clbits; j++)
+            for (uint_t j = 0; j < op->num_clbits; j++)
             {
                 std::cout << op->clbits[j];
                 if (j != op->num_clbits - 1)
@@ -1199,7 +1199,7 @@ void QuantumCircuit::print(void) const
         if (op->num_params > 0)
         {
             std::cout << "[";
-            for (int j = 0; j < op->num_params; j++)
+            for (uint_t j = 0; j < op->num_params; j++)
             {
                 std::cout << op->params[j];
                 if (j != op->num_params - 1)
@@ -1527,7 +1527,7 @@ std::string QuantumCircuit::to_qasm3(void)
         {
             if (op->num_qubits == op->num_clbits)
             {
-                for (int j = 0; j < op->num_qubits; j++)
+                for (uint_t j = 0; j < op->num_qubits; j++)
                 {
                     qasm3 << creg_name << "[" << op->clbits[j] << "] = " << op->name << " " << qreg_name << "[" << op->qubits[j] << "];" << std::endl;
                 }
@@ -1546,7 +1546,7 @@ std::string QuantumCircuit::to_qasm3(void)
             if (op->num_params > 0)
             {
                 qasm3 << "(";
-                for (int j = 0; j < op->num_params; j++)
+                for (uint_t j = 0; j < op->num_params; j++)
                 {
                     qasm3 << op->params[j];
                     if (j != op->num_params - 1)
@@ -1557,7 +1557,7 @@ std::string QuantumCircuit::to_qasm3(void)
             if (op->num_qubits > 0)
             {
                 qasm3 << " ";
-                for (int j = 0; j < op->num_qubits; j++)
+                for (uint_t j = 0; j < op->num_qubits; j++)
                 {
                     qasm3 << qreg_name << "[" << op->qubits[j] << "]";
                     if (j != op->num_qubits - 1)

--- a/src/circuit/quantumregister.hpp
+++ b/src/circuit/quantumregister.hpp
@@ -20,8 +20,10 @@
 #include "circuit/register.hpp"
 #include "qiskit.h"
 
-namespace Qiskit {
-namespace circuit {
+namespace Qiskit
+{
+namespace circuit
+{
 
 // ==================================
 // class for quantum register
@@ -31,56 +33,61 @@ namespace circuit {
 class QuantumRegister : public Register
 {
 protected:
-  std::shared_ptr<QkQuantumRegister> rust_register_ = nullptr;
-  static uint_t instances_counter_;
+    std::shared_ptr<QkQuantumRegister> rust_register_ = nullptr;
+    static uint_t instances_counter_;
+
 public:
-  /// @brief Create a new generic register
-  QuantumRegister()
-  {
-    size_ = 0;
-    name_ = prefix();
-    rust_register_ = nullptr;
-  }
-  /// @brief Create a new QuantumRegister
-  /// @param (size) The number of bits to include in the register
-  QuantumRegister(uint_t size) : Register(size)
-  {
-    name_ = prefix();
-    std::shared_ptr<QkQuantumRegister> reg(qk_quantum_register_new((std::uint32_t)size, (const char*)name_.c_str()), qk_quantum_register_free);
-    rust_register_ = reg;
-  }
-
-  /// @brief Create a new QuantumRegister
-  /// @param (size) The number of bits to include in the register
-  /// @param (name) The name of the register. If not provided, a unique name will be auto-generated from the register type
-  QuantumRegister(uint_t size, std::string name) : Register(size, name) {
-    std::shared_ptr<QkQuantumRegister> reg(qk_quantum_register_new((std::uint32_t)size, (const char*)name.c_str()), qk_quantum_register_free);
-    rust_register_ = reg;
-  }
-
-  /// @brief Create a new QuantumRegister as a copy of reg.
-  /// @param (reg) copy source
-  QuantumRegister(const QuantumRegister& reg) : Register(reg) {
-    rust_register_ = reg.rust_register_;
-  }
-
-  ~QuantumRegister() {
-    if (rust_register_) {
-      rust_register_.reset();
+    /// @brief Create a new generic register
+    QuantumRegister()
+    {
+        size_ = 0;
+        name_ = prefix();
+        rust_register_ = nullptr;
     }
-  }
+    /// @brief Create a new QuantumRegister
+    /// @param (size) The number of bits to include in the register
+    QuantumRegister(uint_t size) : Register(size)
+    {
+        name_ = prefix();
+        std::shared_ptr<QkQuantumRegister> reg(qk_quantum_register_new((std::uint32_t)size, (const char *)name_.c_str()), qk_quantum_register_free);
+        rust_register_ = reg;
+    }
 
-  const std::shared_ptr<QkQuantumRegister>& get_register() const {
-    return rust_register_;
-  }
+    /// @brief Create a new QuantumRegister
+    /// @param (size) The number of bits to include in the register
+    /// @param (name) The name of the register. If not provided, a unique name will be auto-generated from the register type
+    QuantumRegister(uint_t size, std::string name) : Register(size, name)
+    {
+        std::shared_ptr<QkQuantumRegister> reg(qk_quantum_register_new((std::uint32_t)size, (const char *)name.c_str()), qk_quantum_register_free);
+        rust_register_ = reg;
+    }
 
-  std::string prefix(void) override
-  {
-    std::string ret = "q";
-    ret += std::to_string(instances_counter_++);
-    return ret;
-  }
+    /// @brief Create a new QuantumRegister as a copy of reg.
+    /// @param (reg) copy source
+    QuantumRegister(const QuantumRegister &reg) : Register(reg)
+    {
+        rust_register_ = reg.rust_register_;
+    }
 
+    ~QuantumRegister()
+    {
+        if (rust_register_)
+        {
+            rust_register_.reset();
+        }
+    }
+
+    const std::shared_ptr<QkQuantumRegister> &get_register() const
+    {
+        return rust_register_;
+    }
+
+    std::string prefix(void) override
+    {
+        std::string ret = "q";
+        ret += std::to_string(instances_counter_++);
+        return ret;
+    }
 };
 
 uint_t QuantumRegister::instances_counter_ = 0;
@@ -88,5 +95,4 @@ uint_t QuantumRegister::instances_counter_ = 0;
 } // namespace circuit
 } // namespace Qiskit
 
-#endif  // __qiskitcpp_circuit_quantum_register_hpp__
-
+#endif // __qiskitcpp_circuit_quantum_register_hpp__

--- a/src/circuit/register.hpp
+++ b/src/circuit/register.hpp
@@ -19,9 +19,10 @@
 
 #include "utils/types.hpp"
 
-
-namespace Qiskit {
-namespace circuit {
+namespace Qiskit
+{
+namespace circuit
+{
 
 class Register;
 
@@ -32,51 +33,53 @@ class Register;
 /// @brief Implement a generic bit
 class Bit
 {
-  friend Register;
+    friend Register;
+
 protected:
-  uint32_t index_;
-  Register* register_ = nullptr;
+    uint32_t index_;
+    Register *register_ = nullptr;
+
 public:
-  /// @brief Create a new generic bit
-  Bit()
-  {
-    index_ = 0;
-  }
+    /// @brief Create a new generic bit
+    Bit()
+    {
+        index_ = 0;
+    }
 
-  /// @brief Create a new generic bit
-  /// @param (idx) the index of the bit in its containing register
-  /// @param (reg) a register containing the bit
-  Bit(uint32_t idx, Register* reg = nullptr)
-  {
-    index_ = idx;
-    register_ = reg;
-  }
+    /// @brief Create a new generic bit
+    /// @param (idx) the index of the bit in its containing register
+    /// @param (reg) a register containing the bit
+    Bit(uint32_t idx, Register *reg = nullptr)
+    {
+        index_ = idx;
+        register_ = reg;
+    }
 
-  /// @brief Create a new generic bit as a copy of bit.
-  /// @param (bit) copy source
-  Bit(const Bit& bit)
-  {
-    index_ = bit.index_;
-    register_ = bit.register_;
-  }
+    /// @brief Create a new generic bit as a copy of bit.
+    /// @param (bit) copy source
+    Bit(const Bit &bit)
+    {
+        index_ = bit.index_;
+        register_ = bit.register_;
+    }
 
-  /// @brief Return the index of the bit in its containing register.
-  /// @return index value
-  uint32_t index(void)
-  {
-    return index_;
-  }
-  uint32_t global_index(void);
+    /// @brief Return the index of the bit in its containing register.
+    /// @return index value
+    uint32_t index(void)
+    {
+        return index_;
+    }
+    uint32_t global_index(void);
 
-  /// @brief Return the register in this bit in its containing register.
-  /// @return reference to Register
-  Register* get_register(void)
-  {
-    return register_;
-  }
+    /// @brief Return the register in this bit in its containing register.
+    /// @return reference to Register
+    Register *get_register(void)
+    {
+        return register_;
+    }
 
-  // return bit index
-  operator uint32_t() { return global_index(); }
+    // return bit index
+    operator uint32_t() { return global_index(); }
 };
 
 // use same Bit class for both quantum and classical
@@ -90,76 +93,76 @@ using Clbit = Bit;
 /// @brief Implement a generic register
 class Register
 {
-  friend Bit;
+    friend Bit;
+
 protected:
-  uint_t size_;
-  std::string name_;
-  std::vector<Bit> bits_;
-  uint_t base_index_ = 0;
+    uint_t size_;
+    std::string name_;
+    std::vector<Bit> bits_;
+    uint_t base_index_ = 0;
+
 public:
-  /// @brief Create a new generic register
-  Register()
-  {
-  }
-  /// @brief Create a new generic register
-  /// @param (size) The number of bits to include in the register
-  Register(uint_t size) : size_(size)
-  {
-    allocate_bits();
-  }
-  /// @brief Create a new generic register
-  /// @param (size) The number of bits to include in the register
-  /// @param (name) The name of the register. If not provided, a unique name will be auto-generated from the register type.
-  Register(uint_t size, std::string name) : size_(size), name_(name)
-  {
-    allocate_bits();
-  }
-  /// @brief Create a new generic register
-  /// @param (size) The number of bits to include in the register
-  /// @param (name) The name of the register. If not provided, a unique name will be auto-generated from the register type.
-  /// @param (bits) A list of Bit instances to be used to populate the register.
-  Register(uint_t size, std::string name, std::vector<Bit>& bits);
+    /// @brief Create a new generic register
+    Register()
+    {
+    }
+    /// @brief Create a new generic register
+    /// @param (size) The number of bits to include in the register
+    Register(uint_t size) : size_(size)
+    {
+        allocate_bits();
+    }
+    /// @brief Create a new generic register
+    /// @param (size) The number of bits to include in the register
+    /// @param (name) The name of the register. If not provided, a unique name will be auto-generated from the register type.
+    Register(uint_t size, std::string name) : size_(size), name_(name)
+    {
+        allocate_bits();
+    }
+    /// @brief Create a new generic register
+    /// @param (size) The number of bits to include in the register
+    /// @param (name) The name of the register. If not provided, a unique name will be auto-generated from the register type.
+    /// @param (bits) A list of Bit instances to be used to populate the register.
+    Register(uint_t size, std::string name, std::vector<Bit> &bits);
 
-  /// @brief Create a new generic register as a copy of reg
-  /// @param (reg) copy source
-  Register(const Register& reg);
+    /// @brief Create a new generic register as a copy of reg
+    /// @param (reg) copy source
+    Register(const Register &reg);
 
-  /// @brief Resize this register with size
-  /// @param (size) new size of this register
-  void resize(uint_t size)
-  {
-    size_ = size;
-    allocate_bits();
-  }
+    /// @brief Resize this register with size
+    /// @param (size) new size of this register
+    void resize(uint_t size)
+    {
+        size_ = size;
+        allocate_bits();
+    }
 
-  /// @brief Make this register as 1 bit register
-  void make_one_bit_register(Bit& bit)
-  {
-    resize(1);
-    bits_[0] = bit;
-  }
+    /// @brief Make this register as 1 bit register
+    void make_one_bit_register(Bit &bit)
+    {
+        resize(1);
+        bits_[0] = bit;
+    }
 
-  /// @brief Return the size of this register
-  /// @return the size of this register
-  uint_t size(void) { return size_; }
+    /// @brief Return the size of this register
+    /// @return the size of this register
+    uint_t size(void) { return size_; }
 
-  /// @brief Return the name of this register
-  /// @return the name of this register
-  std::string name(){ return name_; }
+    /// @brief Return the name of this register
+    /// @return the name of this register
+    std::string name() { return name_; }
 
-  void set_base_index(uint_t base)
-  {
-    base_index_ = base;
-  }
+    void set_base_index(uint_t base)
+    {
+        base_index_ = base;
+    }
 
-  Bit& operator[](const uint_t i) { return bits_[i]; }
-
-
+    Bit &operator[](const uint_t i) { return bits_[i]; }
 
 protected:
-  virtual std::string prefix(void) = 0;
+    virtual std::string prefix(void) = 0;
 
-  void allocate_bits(void);
+    void allocate_bits(void);
 };
 
 // =======================
@@ -167,52 +170,52 @@ protected:
 // =======================
 uint32_t Bit::global_index(void)
 {
-  if(register_)
-    return register_->base_index_ + index_;
-  return index_;
+    if (register_)
+        return (uint32_t)register_->base_index_ + index_;
+    return index_;
 }
 
 // =======================
 // base class for register
 // =======================
-Register::Register(uint_t size, std::string name, std::vector<Bit>& bits)
+Register::Register(uint_t size, std::string name, std::vector<Bit> &bits)
 {
-  if(size != bits.size()){
-    throw std::runtime_error("Register : size of bits and size is different");
-  }
+    if (size != bits.size())
+    {
+        throw std::runtime_error("Register : size of bits and size is different");
+    }
 
-  size_ = size;
-  bits_ = bits;
+    size_ = size;
+    bits_ = bits;
 
-  for(int_t i=0;i<size;i++){
-    bits[i].register_ = this;
-    bits[i].index_ = i;
-    bits_[i].register_ = this;
-    bits_[i].index_ = i;
-  }
+    for (uint_t i = 0; i < size; i++)
+    {
+        bits[i].register_ = this;
+        bits[i].index_ = (uint32_t)i;
+        bits_[i].register_ = this;
+        bits_[i].index_ = (uint32_t)i;
+    }
 }
 
-Register::Register(const Register& reg)
+Register::Register(const Register &reg)
 {
-  size_ = reg.size_;
-  name_ = reg.name_;
-  bits_ = reg.bits_;
-  base_index_ = reg.base_index_;
+    size_ = reg.size_;
+    name_ = reg.name_;
+    bits_ = reg.bits_;
+    base_index_ = reg.base_index_;
 }
 
 void Register::allocate_bits(void)
 {
-  bits_.resize(size_);
-  for(int_t i=0;i<size_;i++){
-    bits_[i].register_ = this;
-    bits_[i].index_ = i;
-  }
+    bits_.resize(size_);
+    for (uint_t i = 0; i < size_; i++)
+    {
+        bits_[i].register_ = this;
+        bits_[i].index_ = (uint32_t)i;
+    }
 }
-
-
 
 } // namespace circuit
 } // namespace Qiskit
 
-#endif  // __qiskitcpp_circuit_register_hpp__
-
+#endif // __qiskitcpp_circuit_register_hpp__

--- a/src/primitives/containers/bit_array.hpp
+++ b/src/primitives/containers/bit_array.hpp
@@ -104,7 +104,7 @@ void BitArray::from_samples(const reg_t& samples, uint_t num_bits)
 {
     num_bits_ = num_bits;
     array_.resize(samples.size());
-    for (int_t i = 0; i < samples.size(); i++) {
+    for (uint_t i = 0; i < samples.size(); i++) {
         array_[i].from_uint(samples[i], num_bits);
     }
 }
@@ -113,7 +113,7 @@ void BitArray::from_samples(const uint_t* samples, uint_t num_samples, uint_t nu
 {
     num_bits_ = num_bits;
     array_.resize(num_samples);
-    for (int_t i = 0; i < num_samples; i++) {
+    for (uint_t i = 0; i < num_samples; i++) {
         array_[i].from_uint(samples[i], num_bits);
     }
 }
@@ -121,7 +121,7 @@ void BitArray::from_samples(const uint_t* samples, uint_t num_samples, uint_t nu
 void BitArray::from_bitstring(const std::vector<std::string>& samples)
 {
     array_.resize(samples.size());
-    for (int_t i = 0; i < samples.size(); i++) {
+    for (uint_t i = 0; i < samples.size(); i++) {
         array_[i].from_string(samples[i]);
     }
     num_bits_ = array_[0].size();
@@ -130,7 +130,7 @@ void BitArray::from_bitstring(const std::vector<std::string>& samples)
 std::vector<std::string> BitArray::get_bitstring(void)
 {
     std::vector<std::string> ret(array_.size());
-    for (int_t i = 0; i < array_.size(); i++) {
+    for (uint_t i = 0; i < array_.size(); i++) {
         ret[i] = array_[i].to_string();
     }
     return ret;
@@ -139,7 +139,7 @@ std::vector<std::string> BitArray::get_bitstring(void)
 std::vector<std::string> BitArray::get_hexstring(void)
 {
     std::vector<std::string> ret(array_.size());
-    for (int_t i = 0; i < array_.size(); i++) {
+    for (uint_t i = 0; i < array_.size(); i++) {
         ret[i] = array_[i].to_hex_string();
     }
     return ret;
@@ -148,7 +148,7 @@ std::vector<std::string> BitArray::get_hexstring(void)
 std::unordered_map<std::string, uint_t> BitArray::get_counts(void)
 {
     std::unordered_map<std::string, uint_t> ret;
-    for (int_t i = 0; i < array_.size(); i++) {
+    for (uint_t i = 0; i < array_.size(); i++) {
         ret[array_[i].to_string()]++;
     }
     return ret;
@@ -162,7 +162,7 @@ void BitArray::from_json(nlohmann::ordered_json& input)
     if (num_bits_ == 0)
         num_bits_ = num_bits;
     allocate(num_shots, num_bits_);
-    for (int i = 0; i < num_shots; i++) {
+    for (uint_t i = 0; i < num_shots; i++) {
         array_[i].from_hex_string(samples[i]);
     }
 }

--- a/src/providers/qrmi_backend.hpp
+++ b/src/providers/qrmi_backend.hpp
@@ -57,6 +57,15 @@ public:
         qrmi_ = qrmi;
     }
 
+    /// @brief Create a new QRMIBackend from other
+    QRMIBackend(const QRMIBackend& other)
+    {
+        name_ = other.name_;
+        primitive_name_ = other.primitive_name_;
+        qrmi_ = other.qrmi_;
+        target_ = other.target_;
+    }
+
     ~QRMIBackend()
     {
         if (qrmi_) {

--- a/src/quantum_info/sparse_observable.hpp
+++ b/src/quantum_info/sparse_observable.hpp
@@ -20,239 +20,200 @@
 #include "qiskit.h"
 #include "utils/types.hpp"
 
-namespace Qiskit {
-namespace quantum_info {
+namespace Qiskit
+{
+namespace quantum_info
+{
 
 class SparseObservable;
 
 class SparseObservable
 {
 protected:
-  QkObs* obs_;
+    QkObs *obs_;
+
 public:
-  SparseObservable(void) {
-    obs_ = nullptr;
-  }
-  SparseObservable(uint_t num_qubits, std::vector<std::complex<double>>& coeffs, std::vector<QkBitTerm>& terms, reg_t& indicies, reg_t& boundaries);
-  SparseObservable(const SparseObservable& other);
-
-  ~SparseObservable()
-  {
-    if (obs_) {
-      qk_obs_free(obs_);
+    SparseObservable(void)
+    {
+        obs_ = nullptr;
     }
-  }
+    SparseObservable(uint_t num_qubits, std::vector<std::complex<double>> &coeffs, std::vector<QkBitTerm> &terms, reg_t &indicies, reg_t &boundaries);
+    SparseObservable(const SparseObservable &other);
 
-  static SparseObservable zero(uint_t num_qubits)
-  {
-    SparseObservable ret;
-    ret.obs_ = qk_obs_zero(num_qubits);
-    return ret;
-  }
-
-  static SparseObservable identity(uint_t num_qubits)
-  {
-    SparseObservable ret;
-    ret.obs_ = qk_obs_identity(num_qubits);
-    return ret;
-  }
-
-  static SparseObservable from_label(std::string& label);
-  static SparseObservable from_list(std::vector<std::pair<std::string, std::complex<double>>>& list, uint_t num_qubits = 0);
-
-  uint_t num_qubits(void) const
-  {
-    if (obs_) {
-      return qk_obs_num_qubits(obs_);
+    ~SparseObservable()
+    {
+        if (obs_)
+        {
+            qk_obs_free(obs_);
+        }
     }
-    return 0;
-  }
-  uint_t num_terms(void) const
-  {
-    if (obs_) {
-      return qk_obs_num_terms(obs_);
-    }
-    return 0;
-  }
-  std::vector<QkBitTerm> bit_terms(void) const
-  {
-    std::vector<QkBitTerm> ret(num_terms());
-    if (obs_) {
-      auto terms = qk_obs_bit_terms(obs_);
-      for (int i = 0; i < ret.size(); i++) {
-        ret[i] = terms[i];
-      }
-    }
-    return ret;
-  }
-  std::vector<std::complex<double>> coeffs(void) const
-  {
-    std::vector<std::complex<double>> ret(num_terms());
-    if (obs_) {
-      auto cf = qk_obs_coeffs(obs_);
-      for (int i = 0; i < ret.size(); i++) {
-        ret[i] = {cf[i].re, cf[i].im};
-      }
-    }
-    return ret;
-  }
-  reg_t indices(void) const
-  {
-    reg_t ret(qk_obs_len(obs_));
-    if (obs_) {
-      auto idx = qk_obs_indices(obs_);
-      for (int i = 0; i < ret.size(); i++) {
-        ret[i] = idx[i];
-      }
-    }
-    return ret;
-  }
-  reg_t boundaries(void) const
-  {
-    reg_t ret(qk_obs_len(obs_));
-    if (obs_) {
-      auto idx = qk_obs_boundaries(obs_);
-      for (int i = 0; i < ret.size(); i++) {
-        ret[i] = idx[i];
-      }
-    }
-    return ret;
-  }
 
-  SparseObservable operator+(SparseObservable& rhs);
-  SparseObservable& operator+=(SparseObservable& rhs);
-  SparseObservable operator*(std::complex<double>& rhs);
-  SparseObservable& operator*=(std::complex<double>& rhs);
+    static SparseObservable zero(uint_t num_qubits)
+    {
+        SparseObservable ret;
+        ret.obs_ = qk_obs_zero(num_qubits);
+        return ret;
+    }
 
-  bool operator==(SparseObservable& rhs);
+    static SparseObservable identity(uint_t num_qubits)
+    {
+        SparseObservable ret;
+        ret.obs_ = qk_obs_identity(num_qubits);
+        return ret;
+    }
 
-  SparseObservable compose(SparseObservable& other);
+    static SparseObservable from_label(std::string &label);
+    static SparseObservable from_list(std::vector<std::pair<std::string, std::complex<double>>> &list, uint_t num_qubits = 0);
 
-  std::string to_string(void);
+    uint_t num_qubits(void) const
+    {
+        if (obs_)
+        {
+            return qk_obs_num_qubits(obs_);
+        }
+        return 0;
+    }
+    uint_t num_terms(void) const
+    {
+        if (obs_)
+        {
+            return qk_obs_num_terms(obs_);
+        }
+        return 0;
+    }
+    std::vector<QkBitTerm> bit_terms(void) const
+    {
+        std::vector<QkBitTerm> ret(num_terms());
+        if (obs_)
+        {
+            auto terms = qk_obs_bit_terms(obs_);
+            for (int i = 0; i < ret.size(); i++)
+            {
+                ret[i] = terms[i];
+            }
+        }
+        return ret;
+    }
+    std::vector<std::complex<double>> coeffs(void) const
+    {
+        std::vector<std::complex<double>> ret(num_terms());
+        if (obs_)
+        {
+            auto cf = qk_obs_coeffs(obs_);
+            for (int i = 0; i < ret.size(); i++)
+            {
+                ret[i] = {cf[i].re, cf[i].im};
+            }
+        }
+        return ret;
+    }
+    reg_t indices(void) const
+    {
+        reg_t ret(qk_obs_len(obs_));
+        if (obs_)
+        {
+            auto idx = qk_obs_indices(obs_);
+            for (int i = 0; i < ret.size(); i++)
+            {
+                ret[i] = idx[i];
+            }
+        }
+        return ret;
+    }
+    reg_t boundaries(void) const
+    {
+        reg_t ret(qk_obs_len(obs_));
+        if (obs_)
+        {
+            auto idx = qk_obs_boundaries(obs_);
+            for (int i = 0; i < ret.size(); i++)
+            {
+                ret[i] = idx[i];
+            }
+        }
+        return ret;
+    }
+
+    SparseObservable operator+(SparseObservable &rhs);
+    SparseObservable &operator+=(SparseObservable &rhs);
+    SparseObservable operator*(std::complex<double> &rhs);
+    SparseObservable &operator*=(std::complex<double> &rhs);
+
+    bool operator==(SparseObservable &rhs);
+
+    SparseObservable compose(SparseObservable &other);
+
+    std::string to_string(void);
 };
 
-
-SparseObservable::SparseObservable(uint_t num_qubits, std::vector<std::complex<double>>& coeffs, std::vector<QkBitTerm>& bits, reg_t& indicies, reg_t& boundaries)
+SparseObservable::SparseObservable(uint_t num_qubits, std::vector<std::complex<double>> &coeffs, std::vector<QkBitTerm> &bits, reg_t &indicies, reg_t &boundaries)
 {
-  std::vector<std::uint32_t> idx32(indicies.size());
-  for (int i = 0; i < indicies.size(); i++) {
-    idx32[i] = (std::uint32_t)indicies[i];
-  }
-  obs_ = qk_obs_new((std::uint32_t)num_qubits, coeffs.size(), bits.size(), (QkComplex64*)coeffs.data(), bits.data(), idx32.data(), boundaries.data());
-}
-
-SparseObservable::SparseObservable(const SparseObservable& other)
-{
-  obs_ = qk_obs_copy(other.obs_);
-}
-
-SparseObservable SparseObservable::operator+(SparseObservable& rhs)
-{
-  SparseObservable ret;
-  ret.obs_ = qk_obs_add(obs_, rhs.obs_);
-  return ret;
-}
-
-SparseObservable& SparseObservable::operator+=(SparseObservable& rhs)
-{
-  QkObs* t = qk_obs_add(obs_, rhs.obs_);
-  qk_obs_free(obs_);
-  obs_ = t;
-  return *this;
-}
-
-SparseObservable SparseObservable::operator*(std::complex<double>& rhs)
-{
-  SparseObservable ret;
-  ret.obs_ = qk_obs_multiply(obs_, (QkComplex64*)&rhs);
-  return ret;
-}
-SparseObservable& SparseObservable::operator*=(std::complex<double>& rhs)
-{
-  QkObs* t = qk_obs_multiply(obs_, (QkComplex64*)&rhs);
-  qk_obs_free(obs_);
-  obs_ = t;
-  return *this;
-}
-bool SparseObservable::operator==(SparseObservable& rhs)
-{
-  return qk_obs_equal(obs_, rhs.obs_);
-}
-
-SparseObservable SparseObservable::compose(SparseObservable& other)
-{
-  SparseObservable ret;
-  ret.obs_ = qk_obs_compose(obs_, other.obs_);
-  return ret;
-}
-
-SparseObservable SparseObservable::from_label(std::string& label)
-{
-  reg_t indices;
-  reg_t boundaries(2);
-  uint_t num_qubits = label.length();
-  std::vector<QkBitTerm> terms;
-  std::vector<std::complex<double>> coeff(1);
-  coeff[0] = 1.0;
-
-  for (int i=0; i < num_qubits; i++) {
-    switch (label[num_qubits - 1 - i]) {
-      case 'X':
-        terms.push_back(QkBitTerm_X);
-        break;
-      case 'Y':
-        terms.push_back(QkBitTerm_Y);
-        break;
-      case 'Z':
-        terms.push_back(QkBitTerm_Z);
-        break;
-      case '+':
-        terms.push_back(QkBitTerm_Plus);
-        break;
-      case '-':
-        terms.push_back(QkBitTerm_Minus);
-        break;
-      case 'l':
-        terms.push_back(QkBitTerm_Left);
-        break;
-      case 'r':
-        terms.push_back(QkBitTerm_Right);
-        break;
-      case '0':
-        terms.push_back(QkBitTerm_Zero);
-        break;
-      case '1':
-        terms.push_back(QkBitTerm_One);
-        break;
-      default:
-        break;
+    std::vector<std::uint32_t> idx32(indicies.size());
+    for (int i = 0; i < indicies.size(); i++)
+    {
+        idx32[i] = (std::uint32_t)indicies[i];
     }
-    if (indices.size() < terms.size())
-      indices.push_back(i);
-  }
-  boundaries[0] = 0;
-  boundaries[1] = terms.size();
-  return SparseObservable(num_qubits, coeff, terms, indices, boundaries);
+    obs_ = qk_obs_new((std::uint32_t)num_qubits, coeffs.size(), bits.size(), (QkComplex64 *)coeffs.data(), bits.data(), idx32.data(), boundaries.data());
 }
 
-SparseObservable SparseObservable::from_list(std::vector<std::pair<std::string, std::complex<double>>>& list, uint_t num_qubits_in)
+SparseObservable::SparseObservable(const SparseObservable &other)
 {
-  reg_t indices;
-  reg_t boundaries;
-  uint_t num_qubits = num_qubits_in;
-  std::vector<QkBitTerm> terms;
-  std::vector<std::complex<double>> coeffs;
-  boundaries.push_back(0);
+    obs_ = qk_obs_copy(other.obs_);
+}
 
-  for (int i=0; i < list.size(); i++) {
-    if (num_qubits == 0) {
-        num_qubits = list[i].first.length();
-    } else if (num_qubits != list[i].first.length()) {
-      std::cerr << " SparseObservable : Error label with length " << list[i].first.length() << "cannot be added to a " << num_qubits << "-qubits operator" << std::endl;
-      abort();
-    }
-    for (int j=0; j < num_qubits; j++) {
-      switch (list[i].first[num_qubits - 1 - j]) {
+SparseObservable SparseObservable::operator+(SparseObservable &rhs)
+{
+    SparseObservable ret;
+    ret.obs_ = qk_obs_add(obs_, rhs.obs_);
+    return ret;
+}
+
+SparseObservable &SparseObservable::operator+=(SparseObservable &rhs)
+{
+    QkObs *t = qk_obs_add(obs_, rhs.obs_);
+    qk_obs_free(obs_);
+    obs_ = t;
+    return *this;
+}
+
+SparseObservable SparseObservable::operator*(std::complex<double> &rhs)
+{
+    SparseObservable ret;
+    ret.obs_ = qk_obs_multiply(obs_, (QkComplex64 *)&rhs);
+    return ret;
+}
+SparseObservable &SparseObservable::operator*=(std::complex<double> &rhs)
+{
+    QkObs *t = qk_obs_multiply(obs_, (QkComplex64 *)&rhs);
+    qk_obs_free(obs_);
+    obs_ = t;
+    return *this;
+}
+bool SparseObservable::operator==(SparseObservable &rhs)
+{
+    return qk_obs_equal(obs_, rhs.obs_);
+}
+
+SparseObservable SparseObservable::compose(SparseObservable &other)
+{
+    SparseObservable ret;
+    ret.obs_ = qk_obs_compose(obs_, other.obs_);
+    return ret;
+}
+
+SparseObservable SparseObservable::from_label(std::string &label)
+{
+    reg_t indices;
+    reg_t boundaries(2);
+    uint_t num_qubits = label.length();
+    std::vector<QkBitTerm> terms;
+    std::vector<std::complex<double>> coeff(1);
+    coeff[0] = 1.0;
+
+    for (int i = 0; i < num_qubits; i++)
+    {
+        switch (label[num_qubits - 1 - i])
+        {
         case 'X':
             terms.push_back(QkBitTerm_X);
             break;
@@ -282,29 +243,87 @@ SparseObservable SparseObservable::from_list(std::vector<std::pair<std::string, 
             break;
         default:
             break;
-      }
-      if (indices.size() < terms.size())
-        indices.push_back(j);
+        }
+        if (indices.size() < terms.size())
+            indices.push_back(i);
     }
-    boundaries.push_back(terms.size());
-    coeffs.push_back(list[i].second);
-  }
-  return SparseObservable(num_qubits, coeffs, terms, indices, boundaries);
+    boundaries[0] = 0;
+    boundaries[1] = terms.size();
+    return SparseObservable(num_qubits, coeff, terms, indices, boundaries);
+}
+
+SparseObservable SparseObservable::from_list(std::vector<std::pair<std::string, std::complex<double>>> &list, uint_t num_qubits_in)
+{
+    reg_t indices;
+    reg_t boundaries;
+    uint_t num_qubits = num_qubits_in;
+    std::vector<QkBitTerm> terms;
+    std::vector<std::complex<double>> coeffs;
+    boundaries.push_back(0);
+
+    for (int i = 0; i < list.size(); i++)
+    {
+        if (num_qubits == 0)
+        {
+            num_qubits = list[i].first.length();
+        }
+        else if (num_qubits != list[i].first.length())
+        {
+            std::cerr << " SparseObservable : Error label with length " << list[i].first.length() << "cannot be added to a " << num_qubits << "-qubits operator" << std::endl;
+            abort();
+        }
+        for (int j = 0; j < num_qubits; j++)
+        {
+            switch (list[i].first[num_qubits - 1 - j])
+            {
+            case 'X':
+                terms.push_back(QkBitTerm_X);
+                break;
+            case 'Y':
+                terms.push_back(QkBitTerm_Y);
+                break;
+            case 'Z':
+                terms.push_back(QkBitTerm_Z);
+                break;
+            case '+':
+                terms.push_back(QkBitTerm_Plus);
+                break;
+            case '-':
+                terms.push_back(QkBitTerm_Minus);
+                break;
+            case 'l':
+                terms.push_back(QkBitTerm_Left);
+                break;
+            case 'r':
+                terms.push_back(QkBitTerm_Right);
+                break;
+            case '0':
+                terms.push_back(QkBitTerm_Zero);
+                break;
+            case '1':
+                terms.push_back(QkBitTerm_One);
+                break;
+            default:
+                break;
+            }
+            if (indices.size() < terms.size())
+                indices.push_back(j);
+        }
+        boundaries.push_back(terms.size());
+        coeffs.push_back(list[i].second);
+    }
+    return SparseObservable(num_qubits, coeffs, terms, indices, boundaries);
 }
 
 std::string SparseObservable::to_string(void)
 {
-  char* str = qk_obs_str(obs_);
-  std::string ret = str;
-  qk_str_free(str);
-  return ret;
+    char *str = qk_obs_str(obs_);
+    std::string ret = str;
+    qk_str_free(str);
+    return ret;
 }
-
 
 } // namespace quantum_info
 } // namespace Qiskit
 
-
-
-
-#endif  //__qiskitcpp_quantum_info_sparse_observable_hpp__
+#endif //__qiskitcpp_quantum_info_sparse_observable_hpp__

--- a/src/service/qiskit_runtime_service.hpp
+++ b/src/service/qiskit_runtime_service.hpp
@@ -48,11 +48,22 @@ public:
     /// @brief Create a new QRMIBackend
     QiskitRuntimeService()
     {
+#ifdef _MSC_VER
+        char* token = nullptr;
+        size_t len;
+        _dupenv_s(&token, &len, "QISKIT_IBM_TOKEN");
+#else
         char* token = getenv("QISKIT_IBM_TOKEN");
+#endif
         if (token != nullptr) {
             token_ = token;
         }
+#ifdef _MSC_VER
+        char* crn = nullptr;
+        _dupenv_s(&crn, &len, "QISKIT_IBM_INSTANCE");
+#else
         char* crn = getenv("QISKIT_IBM_INSTANCE");
+#endif
         if (crn != nullptr) {
             instance_ = crn;
         }
@@ -84,7 +95,6 @@ public:
         if (instance.length() > 0) {
             instance_ = instance;
         }
-
         // get API key and CRN from env and set env for QRMI C-API
         if (token_.length() == 0) {
             std::cerr << " ERROR: please set your API key to \"QISKIT_IBM_TOKEN\" environment variable" << std::endl;
@@ -105,18 +115,25 @@ public:
             header = "_QRMI_IBM_QRS_";
         }
 
+#ifdef _MSC_VER
+        std::string envEndPoint = name + header + "ENDPOINT";
+        std::string varEndPoint = url_ + "/api/v1";
+        std::string envIAMEndPoint = name + header + "IAM_ENDPOINT";
+        std::string envAPIKey = name + header + "IAM_APIKEY";
+        std::string envCRN = name + header + "SERVICE_CRN";
+        std::string envSession = name + header + "SESSION_MODE";
+
+        _putenv_s(envEndPoint.c_str(), varEndPoint.c_str());
+        _putenv_s(envIAMEndPoint.c_str(), iam_url_.c_str());
+        _putenv_s(envAPIKey.c_str(), token_.c_str());
+        _putenv_s(envCRN.c_str(), instance_.c_str());
+        _putenv_s(envSession.c_str(), session_mode_.c_str());
+#else
         std::string envEndPoint = name + header + "ENDPOINT=" + url_ + "/api/v1";
         std::string envIAMEndPoint = name + header + "IAM_ENDPOINT=" + iam_url_;
         std::string envAPIKey = name + header + "IAM_APIKEY=" + token_;
         std::string envCRN = name + header + "SERVICE_CRN=" + instance_;
         std::string envSession = name + header + "SESSION_MODE=" + session_mode_;
-#ifdef _MSC_VER
-        _putenv(envEndPoint.c_str());
-        _putenv(envIAMEndPoint.c_str());
-        _putenv(envAPIKey.c_str());
-        _putenv(envCRN.c_str());
-        _putenv(envSession.c_str());
-#else
         putenv((char*)envEndPoint.c_str());
         putenv((char*)envIAMEndPoint.c_str());
         putenv((char*)envAPIKey.c_str());

--- a/src/transpiler/target.hpp
+++ b/src/transpiler/target.hpp
@@ -25,181 +25,206 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
-
-namespace Qiskit {
-namespace transpiler {
+namespace Qiskit
+{
+namespace transpiler
+{
 
 /// @class Target
 /// @brief target object to describe backend's properties
-class Target {
+class Target
+{
 protected:
-  QkTarget* target_ = nullptr;
-  std::string backend_name_;
-  std::vector<std::string> basis_gates_;
-  double dt_;
-  uint_t max_experiments_;
-  uint_t max_shots_;
-  uint_t num_qubits_ = 0;
-  bool is_set_ = false;
+    QkTarget *target_ = nullptr;
+    std::string backend_name_;
+    std::vector<std::string> basis_gates_;
+    double dt_;
+    uint_t max_experiments_;
+    uint_t max_shots_;
+    uint_t num_qubits_ = 0;
+    bool is_set_ = false;
+
 public:
-  /// @brief Create a new target
-  Target() {}
+    /// @brief Create a new target
+    Target() {}
 
-  ~Target()
-  {
-    if (target_) {
-      qk_target_free(target_);
+    ~Target()
+    {
+        if (target_)
+        {
+            qk_target_free(target_);
+        }
     }
-  }
-  bool is_set(void) const
-  {
-    return is_set_;
-  }
-  const QkTarget* rust_target(void) const
-  {
-    return target_;
-  }
+    bool is_set(void) const
+    {
+        return is_set_;
+    }
+    const QkTarget *rust_target(void) const
+    {
+        return target_;
+    }
 
-  /// @brief name of the target
-  /// @return name of target
-  const std::string& name(void) const
-  {
-    return backend_name_;
-  }
+    /// @brief name of the target
+    /// @return name of target
+    const std::string &name(void) const
+    {
+        return backend_name_;
+    }
 
-  /// @brief number of qubits
-  /// @return number of qubits
-  uint_t num_qubits(void) const
-  {
-    return num_qubits_;
-  }
+    /// @brief number of qubits
+    /// @return number of qubits
+    uint_t num_qubits(void) const
+    {
+        return num_qubits_;
+    }
 
-  /// @brief basis gates for this target
-  /// @return a list of basis gates in string
-  const std::vector<std::string>& basis_gates(void) const
-  {
-    return basis_gates_;
-  }
+    /// @brief basis gates for this target
+    /// @return a list of basis gates in string
+    const std::vector<std::string> &basis_gates(void) const
+    {
+        return basis_gates_;
+    }
 
-  /// @brief make target from json
-  /// @param input json target obtained from IQP
-  /// @return true if target is successfully made
-  bool from_json(nlohmann::ordered_json& input);
+    /// @brief make target from json
+    /// @param input json target obtained from IQP
+    /// @return true if target is successfully made
+    bool from_json(nlohmann::ordered_json &input);
 };
 
-
-bool Target::from_json(nlohmann::ordered_json& input)
+bool Target::from_json(nlohmann::ordered_json &input)
 {
-  auto backend_configuration = input["configuration"];
-  auto backend_properties = input["properties"];
-  if (target_) {
-    qk_target_free(target_);
-  }
-
-  num_qubits_ = backend_configuration["n_qubits"];
-
-  target_ = qk_target_new(num_qubits_);
-  if (target_ == nullptr)
-    return false;
-
-  dt_ = backend_configuration["dt"];
-  max_experiments_ = backend_configuration["max_experiments"];
-  max_shots_ = backend_configuration["max_shots"];
-
-  // set target configs available in C-API
-  qk_target_set_dt(target_, dt_);
-  qk_target_set_granularity(target_, backend_configuration["timing_constraints"]["granularity"]);
-  qk_target_set_min_length(target_, backend_configuration["timing_constraints"]["min_length"]);
-  qk_target_set_pulse_alignment(target_, backend_configuration["timing_constraints"]["pulse_alignment"]);
-  qk_target_set_acquire_alignment(target_, backend_configuration["timing_constraints"]["acquire_alignment"]);
-
-  // get basis gates and make property entries
-  auto name_map = Qiskit::circuit::get_standard_gate_name_mapping();
-  for (auto& gate : backend_configuration["basis_gates"]) {
-    basis_gates_.push_back(gate);
-  }
-
-  // add gate properties
-  std::unordered_map<std::string, QkTargetEntry*> property_map;
-  for (auto& prop : backend_properties["gates"]) {
-    std::string gate = prop["gate"];
-    if (gate == "rzz") {
-      // TODO: Add RZZ support when we have angle wrapping in
-      // Qiskit's target and C transpiler.
-      continue;
-    }
-    std::vector<uint32_t> qubits = prop["qubits"];
-    double duration = 0.0;
-    double error = 0.0;
-    for (auto& param : prop["parameters"]) {
-      if (param["name"] == "gate_error") {
-        error = param["value"];
-      } else if (param["name"] == "gate_length") {
-        duration = 1e-9 * (double)param["value"];
-      }
+    auto backend_configuration = input["configuration"];
+    auto backend_properties = input["properties"];
+    if (target_)
+    {
+        qk_target_free(target_);
     }
 
-    QkTargetEntry* target_entry = nullptr;
-    auto entry = property_map.find(gate);
-    if (entry == property_map.end()) {
-      auto inst = name_map.find(gate);
-      if (inst == name_map.end()) {
-        if (gate == "reset") {
-          target_entry = qk_target_entry_new_reset();
-          property_map[gate] = target_entry;
+    num_qubits_ = backend_configuration["n_qubits"];
+
+    target_ = qk_target_new((uint32_t)num_qubits_);
+    if (target_ == nullptr)
+        return false;
+
+    dt_ = backend_configuration["dt"];
+    max_experiments_ = backend_configuration["max_experiments"];
+    max_shots_ = backend_configuration["max_shots"];
+
+    // set target configs available in C-API
+    qk_target_set_dt(target_, dt_);
+    qk_target_set_granularity(target_, backend_configuration["timing_constraints"]["granularity"]);
+    qk_target_set_min_length(target_, backend_configuration["timing_constraints"]["min_length"]);
+    qk_target_set_pulse_alignment(target_, backend_configuration["timing_constraints"]["pulse_alignment"]);
+    qk_target_set_acquire_alignment(target_, backend_configuration["timing_constraints"]["acquire_alignment"]);
+
+    // get basis gates and make property entries
+    auto name_map = Qiskit::circuit::get_standard_gate_name_mapping();
+    for (auto &gate : backend_configuration["basis_gates"])
+    {
+        basis_gates_.push_back(gate);
+    }
+
+    // add gate properties
+    std::unordered_map<std::string, QkTargetEntry *> property_map;
+    for (auto &prop : backend_properties["gates"])
+    {
+        std::string gate = prop["gate"];
+        if (gate == "rzz")
+        {
+            // TODO: Add RZZ support when we have angle wrapping in
+            // Qiskit's target and C transpiler.
+            continue;
         }
-      } else {
-        target_entry = qk_target_entry_new(inst->second.gate_map());
-        property_map[gate] = target_entry;
-      }
-    } else {
-      target_entry = entry->second;
-    }
-    if (target_entry) {
-      QkExitCode ret = qk_target_entry_add_property(target_entry, qubits.data(), qubits.size(), duration, error);
-      if (ret != QkExitCode_Success) {
-        std::cerr << " target qk_target_entry_add_property error (" << ret << ") : " << gate << " [";
-        for (int i = 0; i < qubits.size(); i++) {
-          std::cerr << qubits[i] << ", ";
+        std::vector<uint32_t> qubits = prop["qubits"];
+        double duration = 0.0;
+        double error = 0.0;
+        for (auto &param : prop["parameters"])
+        {
+            if (param["name"] == "gate_error")
+            {
+                error = param["value"];
+            }
+            else if (param["name"] == "gate_length")
+            {
+                duration = 1e-9 * (double)param["value"];
+            }
         }
-        std::cerr << "]" << std::endl;
-      }
-    }
-  }
 
-  for (auto& entry : property_map) {
-    QkExitCode ret = qk_target_add_instruction(target_, entry.second);
-    if (ret != QkExitCode_Success) {
-      std::cerr << " target qk_target_add_instruction error (" << ret << ")" << std::endl;
+        QkTargetEntry *target_entry = nullptr;
+        auto entry = property_map.find(gate);
+        if (entry == property_map.end())
+        {
+            auto inst = name_map.find(gate);
+            if (inst == name_map.end())
+            {
+                if (gate == "reset")
+                {
+                    target_entry = qk_target_entry_new_reset();
+                    property_map[gate] = target_entry;
+                }
+            }
+            else
+            {
+                target_entry = qk_target_entry_new(inst->second.gate_map());
+                property_map[gate] = target_entry;
+            }
+        }
+        else
+        {
+            target_entry = entry->second;
+        }
+        if (target_entry)
+        {
+            QkExitCode ret = qk_target_entry_add_property(target_entry, qubits.data(), (uint32_t)qubits.size(), duration, error);
+            if (ret != QkExitCode_Success)
+            {
+                std::cerr << " target qk_target_entry_add_property error (" << ret << ") : " << gate << " [";
+                for (int i = 0; i < qubits.size(); i++)
+                {
+                    std::cerr << qubits[i] << ", ";
+                }
+                std::cerr << "]" << std::endl;
+            }
+        }
     }
-//    qk_target_entry_free(entry.second);
-  }
 
-  // add measure properties
-  QkTargetEntry* measure = qk_target_entry_new_measure();
-  uint32_t qubit = 0;
-  for (uint32_t qubit = 0; qubit < backend_properties["qubits"].size(); qubit++) {
-    double duration = 0.0;
-    double error = 0.0;
-    for (auto& param : backend_properties["qubits"][qubit]) {
-      if (param["name"] == "readout_error") {
-        error = param["value"];
-      } else if (param["name"] == "readout_length") {
-        duration = 1e-9 * (double)param["value"];
-      }
+    for (auto &entry : property_map)
+    {
+        QkExitCode ret = qk_target_add_instruction(target_, entry.second);
+        if (ret != QkExitCode_Success)
+        {
+            std::cerr << " target qk_target_add_instruction error (" << ret << ")" << std::endl;
+        }
+        //    qk_target_entry_free(entry.second);
     }
-    qk_target_entry_add_property(measure, &qubit, 1, duration, error);
-  }
-  qk_target_add_instruction(target_, measure);
 
-  is_set_ = true;
-  return true;
+    // add measure properties
+    QkTargetEntry *measure = qk_target_entry_new_measure();
+    uint32_t qubit = 0;
+    for (uint32_t qubit = 0; qubit < backend_properties["qubits"].size(); qubit++)
+    {
+        double duration = 0.0;
+        double error = 0.0;
+        for (auto &param : backend_properties["qubits"][qubit])
+        {
+            if (param["name"] == "readout_error")
+            {
+                error = param["value"];
+            }
+            else if (param["name"] == "readout_length")
+            {
+                duration = 1e-9 * (double)param["value"];
+            }
+        }
+        qk_target_entry_add_property(measure, &qubit, 1, duration, error);
+    }
+    qk_target_add_instruction(target_, measure);
+
+    is_set_ = true;
+    return true;
 }
-
-
 
 } // namespace transpiler
 } // namespace Qiskit
-
 
 #endif //__qiskitcpp_transpiler_target_def_hpp__

--- a/src/utils/bitvector.hpp
+++ b/src/utils/bitvector.hpp
@@ -192,7 +192,7 @@ void BitVector::from_hex_string(const std::string &src, const uint_t base)
     if (size * 4 > ((size_ + 3) / 4) * 4)
         allocate(size * 4, base);
 
-    for (int_t i = 0; i < size; i++)
+    for (uint_t i = 0; i < size; i++)
     {
         char c = src[src.size() - 1 - i];
         uint_t h = 0;
@@ -278,11 +278,11 @@ std::string BitVector::to_hex_string(void)
 
         if (val < 10)
         {
-            str[str.size() - 1 - i] = ('0' + val);
+            str[str.size() - 1 - i] = ('0' + (char)val);
         }
         else
         {
-            str[str.size() - 1 - i] = ('a' + (val - 10));
+            str[str.size() - 1 - i] = ('a' + (char)(val - 10));
         }
     }
     return str;

--- a/src/utils/rng.hpp
+++ b/src/utils/rng.hpp
@@ -23,7 +23,8 @@
 
 #include "utils/types.hpp"
 
-namespace Qiskit {
+namespace Qiskit
+{
 
 //============================================================================
 // RngEngine Class
@@ -37,114 +38,117 @@ namespace Qiskit {
 /// @class RngEngine
 /// @brief Objects of this class are used to generate random numbers for backends.
 /// These are used to decide outcomes of measurements and resets, and for implementing noise.
-class RngEngine {
+class RngEngine
+{
 public:
-  //-----------------------------------------------------------------------
-  // Constructors
-  //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
+    // Constructors
+    //-----------------------------------------------------------------------
 
-  // Default constructor initialize RNG engine with a random seed
-  /// @brief Default constructor initialize RNG engine with a random seed
-  RngEngine() { set_random_seed(); }
+    // Default constructor initialize RNG engine with a random seed
+    /// @brief Default constructor initialize RNG engine with a random seed
+    RngEngine() { set_random_seed(); }
 
-  // Seeded constructor initialize RNG engine with a fixed seed
-  /// @brief Seeded constructor initialize RNG engine with a fixed seed
-  explicit RngEngine(size_t seed) { set_seed(seed); }
+    // Seeded constructor initialize RNG engine with a fixed seed
+    /// @brief Seeded constructor initialize RNG engine with a fixed seed
+    explicit RngEngine(size_t seed) { set_seed(seed); }
 
-  //-----------------------------------------------------------------------
-  // Set fixed or random seed for RNG
-  //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
+    // Set fixed or random seed for RNG
+    //-----------------------------------------------------------------------
 
-  // Set random seed for the RNG engine
-  /// @brief Set random seed for the RNG engine
-  void set_random_seed() {
-    std::random_device rd;
-    set_seed(rd());
-  }
+    // Set random seed for the RNG engine
+    /// @brief Set random seed for the RNG engine
+    void set_random_seed()
+    {
+        std::random_device rd;
+        set_seed(rd());
+    }
 
-  // Set a fixed seed for the RNG engine
-  /// @brief Set a fixed seed for the RNG engine
-  /// @param (seed) generator seed
-  void set_seed(size_t seed) {
-    rng.seed(seed);
-    initial_seed_ = seed;
-  }
+    // Set a fixed seed for the RNG engine
+    /// @brief Set a fixed seed for the RNG engine
+    /// @param (seed) generator seed
+    void set_seed(size_t seed)
+    {
+        rng.seed(seed);
+        initial_seed_ = seed;
+    }
 
-  /// @brief Return seed used to initialize rng engine
-  /// @return seed used to initialize rng engine
-  size_t initial_seed(void) { return initial_seed_; }
+    /// @brief Return seed used to initialize rng engine
+    /// @return seed used to initialize rng engine
+    size_t initial_seed(void) { return initial_seed_; }
 
-  //-----------------------------------------------------------------------
-  // Sampling methods
-  //-----------------------------------------------------------------------
+    //-----------------------------------------------------------------------
+    // Sampling methods
+    //-----------------------------------------------------------------------
 
-  // Generate a uniformly distributed pseudo random real in the half-open
-  // interval [a,b)
-  /// @brief Generate a uniformly distributed pseudo random real in the half-open
-  /// interval [a,b)
-  /// @param (a) a of [a, b)
-  /// @param (b) b of [a, b)
-  /// @return a uniformly distributed pseudo random real
-  double rand(double a, double b) {
-    return std::uniform_real_distribution<double>(a, b)(rng);
-  }
+    // Generate a uniformly distributed pseudo random real in the half-open
+    // interval [a,b)
+    /// @brief Generate a uniformly distributed pseudo random real in the half-open
+    /// interval [a,b)
+    /// @param (a) a of [a, b)
+    /// @param (b) b of [a, b)
+    /// @return a uniformly distributed pseudo random real
+    double rand(double a, double b)
+    {
+        return std::uniform_real_distribution<double>(a, b)(rng);
+    }
 
-  // Generate a uniformly distributed pseudo random real in the half-open
-  // interval [0,b)
-  /// @brief Generate a uniformly distributed pseudo random real in the half-open
-  /// interval [0,b)
-  /// @param (b) b of [0, b)
-  /// @return a uniformly distributed pseudo random real
-  double rand(double b) { return rand(double(0), b); };
+    // Generate a uniformly distributed pseudo random real in the half-open
+    // interval [0,b)
+    /// @brief Generate a uniformly distributed pseudo random real in the half-open
+    /// interval [0,b)
+    /// @param (b) b of [0, b)
+    /// @return a uniformly distributed pseudo random real
+    double rand(double b) { return rand(double(0), b); };
 
-  // Generate a uniformly distributed pseudo random real in the half-open
-  // interval [0,1)
-  /// @brief Generate a uniformly distributed pseudo random real in the half-open
-  /// interval [0,1)
-  /// @return a uniformly distributed pseudo random real
-  double rand() { return rand(0, 1); };
+    // Generate a uniformly distributed pseudo random real in the half-open
+    // interval [0,1)
+    /// @brief Generate a uniformly distributed pseudo random real in the half-open
+    /// interval [0,1)
+    /// @return a uniformly distributed pseudo random real
+    double rand() { return rand(0, 1); };
 
-  // Generate a normal distributed pseudo random real in the half-open
-  // interval [a,b)
-  /// @brief Generate a normal distributed pseudo random real in the half-open
-  /// interval [a,b)
-  /// @return a normal distributed pseudo random real
-  double normal() {
-    return std::normal_distribution<double>(0.0, 1.0)(rng);
-  }
+    // Generate a normal distributed pseudo random real in the half-open
+    // interval [a,b)
+    /// @brief Generate a normal distributed pseudo random real in the half-open
+    /// interval [a,b)
+    /// @return a normal distributed pseudo random real
+    double normal()
+    {
+        return std::normal_distribution<double>(0.0, 1.0)(rng);
+    }
 
-  // make permutation array
-  /// @brief  make permutation array
-  reg_t permutation(uint_t n)
-  {
-    reg_t ret(n);
-    for (uint_t i = 0; i < n; i++)
-      ret[i] = i;
-    std::shuffle(ret.begin(), ret.end(), rng);
-    return ret;
-  }
+    // make permutation array
+    /// @brief  make permutation array
+    reg_t permutation(uint_t n)
+    {
+        reg_t ret(n);
+        for (uint_t i = 0; i < n; i++)
+            ret[i] = i;
+        std::shuffle(ret.begin(), ret.end(), rng);
+        return ret;
+    }
 
-  // Generate a uniformly distributed pseudo random integer in the closed
-  // interval [a,b]
-  template <typename Integer,
-            typename = std::enable_if_t<::std::is_integral<Integer>::value>>
-  Integer rand_int(Integer a, Integer b) {
-    return std::uniform_int_distribution<Integer>(a, b)(rng);
-  }
+    // Generate a uniformly distributed pseudo random integer in the closed
+    // interval [a,b]
+    uint_t rand_int(uint_t a, uint_t b)
+    {
+        return std::uniform_int_distribution<uint_t>(a, b)(rng);
+    }
 
-  // Generate a pseudo random integer from a a discrete distribution
-  // constructed from an input vector of probabilities for [0,..,n-1]
-  // where n is the lenght of the vector. If this vector is not normalized
-  // it will be scaled when it is converted to a discrete_distribution
-  template <typename Float,
-            typename = std::enable_if_t<std::is_floating_point<Float>::value>>
-  size_t rand_int(const std::vector<Float> &probs) {
-    return std::discrete_distribution<size_t>(probs.begin(), probs.end())(rng);
-  }
+    // Generate a pseudo random integer from a a discrete distribution
+    // constructed from an input vector of probabilities for [0,..,n-1]
+    // where n is the lenght of the vector. If this vector is not normalized
+    // it will be scaled when it is converted to a discrete_distribution
+    size_t rand_int(const std::vector<double> &probs)
+    {
+        return std::discrete_distribution<size_t>(probs.begin(), probs.end())(rng);
+    }
 
 private:
-  std::mt19937_64 rng;  // Mersenne twister rng engine
-  size_t initial_seed_; // save seed used to initialize rng engine
+    std::mt19937_64 rng;  // Mersenne twister rng engine
+    size_t initial_seed_; // save seed used to initialize rng engine
 };
 
 //------------------------------------------------------------------------------

--- a/src/utils/types.hpp
+++ b/src/utils/types.hpp
@@ -24,8 +24,8 @@
 namespace Qiskit {
 
 // Numeric Types
-using int_t = int_fast64_t;
-using uint_t = uint_fast64_t;
+using int_t = std::int64_t;
+using uint_t = std::uint64_t;
 using int32_t = std::int32_t;
 using uint32_t = std::uint32_t;
 using complex_t = std::complex<double>;

--- a/tests/observable_test.cpp
+++ b/tests/observable_test.cpp
@@ -23,22 +23,22 @@ using namespace Qiskit::quantum_info;
 
 int main()
 {
-  auto a = SparseObservable::zero(10);
-  auto b = SparseObservable::identity(10);
-  a += b;
-  std::cout << a.to_string() <<std::endl;
+    auto a = SparseObservable::zero(10);
+    auto b = SparseObservable::identity(10);
+    a += b;
+    std::cout << a.to_string() <<std::endl;
 
 
-  std::string label = "-III+IZIXXYXI";
-  auto c = SparseObservable::from_label(label);
-  std::cout << c.to_string() <<std::endl;
+    std::string label = "-III+IZIXXYXI";
+    auto c = SparseObservable::from_label(label);
+    std::cout << c.to_string() <<std::endl;
 
-  std::vector<std::pair<std::string, std::complex<double>>> list;
-  list.push_back(std::make_pair(std::string("IIIXXIZYII"), std::complex(1.0)));
-  list.push_back(std::make_pair(std::string("I++IZIIXII"), std::complex(-1.0)));
-  auto d = SparseObservable::from_list(list);
-  std::cout << d.to_string() <<std::endl;
+    std::vector<std::pair<std::string, std::complex<double>>> list;
+    list.push_back(std::make_pair(std::string("IIIXXIZYII"), std::complex<double>(1.0)));
+    list.push_back(std::make_pair(std::string("I++IZIIXII"), std::complex<double>(-1.0)));
+    auto d = SparseObservable::from_list(list);
+    std::cout << d.to_string() <<std::endl;
 
-  return 0;
+    return 0;
 }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fix compatibility issues for C++11

### Details and comments

For older HPC environments, Qiskit C++ should be C++11 compatible.
Now Qiskit C++ can be built with `-std=c++11`

