### PR TITLE
Add functions to handle multiple cregs and bitcounts

### DIFF
--- a/releasenotes/notes/add_support_multiple_cregs-db972b595457f252.yaml
+++ b/releasenotes/notes/add_support_multiple_cregs-db972b595457f252.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Sampler pub result can return separate `BitArray` for each classical registers.
+
+    `BitArray` adds new functions.
+    `bitcount()` returns number of 1 bits in each bitstrings.
+    `get_counts()` and `get_bitstrings()` can have a list of index which element should be included in the map of counts
+    `get_bitstring` is renamed by `get_bitstrings`
+

--- a/src/circuit/quantumcircuit_def.hpp
+++ b/src/circuit/quantumcircuit_def.hpp
@@ -88,7 +88,7 @@ public:
 	/// @param qregs A list of QuantumRegister
 	/// @param cregs A list of ClassicalRegister
 	/// @param global_phase The global phase of the circuit, measured in radians
-	QuantumCircuit(std::vector<QuantumRegister> &qregs, std::vector<ClassicalRegister> &cregs, const double global_phase = 0.0);
+	QuantumCircuit(std::vector<QuantumRegister> qregs, std::vector<ClassicalRegister> cregs, const double global_phase = 0.0);
 
 	/// @brief Create a new reference to Quantum Circuit
 	/// @details Copy constructor of QuantumCircuit does not copy the circuit,
@@ -122,6 +122,34 @@ public:
 		return num_clbits_;
 	}
 
+	/// @brief Return number of qregs
+	/// @return number of qregs
+	uint_t num_qregs(void) const
+	{
+		return qregs_.size();
+	}
+
+	/// @brief Return number of cregs
+	/// @return number of cregs
+	uint_t num_cregs(void) const
+	{
+		return cregs_.size();
+	}
+
+	/// @brief Return a list of qregs
+	/// @return reference to a list of qregs
+	const std::vector<QuantumRegister>& qregs(void) const
+	{
+		return qregs_;
+	}
+
+	/// @brief Return a list of cregs
+	/// @return reference to a list of cregs
+	const std::vector<ClassicalRegister>& cregs(void) const
+	{
+		return cregs_;
+	}
+
 	std::shared_ptr<rust_circuit> get_rust_circuit(const bool update = true)
 	{
 		if (update)
@@ -133,9 +161,10 @@ public:
 	/// @return copied circuit
 	QuantumCircuit copy(void);
 
-	/// @brief set circuit reference of Rust's circuit
+	/// @brief set circuit reference of Qiskit circuit
 	/// @param circ smart pointer to RUst circuit
-	void from_rust_circuit(std::shared_ptr<rust_circuit> circ, const std::vector<uint32_t> &map);
+	/// @param map layout mapping
+	void set_qiskit_circuit(std::shared_ptr<rust_circuit> circ, const std::vector<uint32_t> &map);
 
 	/// @brief set target to this circuit
 	/// @param target smart pointer to target

--- a/src/circuit/quantumcircuit_impl.hpp
+++ b/src/circuit/quantumcircuit_impl.hpp
@@ -47,7 +47,7 @@ QuantumCircuit::QuantumCircuit(const uint_t num_qubits, const uint_t num_clbits,
     qregs_[0] = qr;
     cregs_[0] = cr;
 
-    rust_circuit_ = std::shared_ptr<rust_circuit>(qk_circuit_new((std::uint32_t)num_qubits_, (std::uint32_t)num_clbits_), qk_circuit_free);
+    rust_circuit_ = std::shared_ptr<rust_circuit>(qk_circuit_new(0, 0), qk_circuit_free);
     qk_circuit_add_quantum_register(rust_circuit_.get(), qregs_[0].get_register().get());
     qk_circuit_add_classical_register(rust_circuit_.get(), cregs_[0].get_register().get());
 
@@ -69,7 +69,7 @@ QuantumCircuit::QuantumCircuit(QuantumRegister &qreg, ClassicalRegister &creg, c
     qregs_[0] = qreg;
     cregs_[0] = creg;
 
-    rust_circuit_ = std::shared_ptr<rust_circuit>(qk_circuit_new((std::uint32_t)num_qubits_, (std::uint32_t)num_clbits_), qk_circuit_free);
+    rust_circuit_ = std::shared_ptr<rust_circuit>(qk_circuit_new(0, 0), qk_circuit_free);
 
     qk_circuit_add_quantum_register(rust_circuit_.get(), qregs_[0].get_register().get());
     qk_circuit_add_classical_register(rust_circuit_.get(), cregs_[0].get_register().get());
@@ -80,7 +80,7 @@ QuantumCircuit::QuantumCircuit(QuantumRegister &qreg, ClassicalRegister &creg, c
     }
 }
 
-QuantumCircuit::QuantumCircuit(std::vector<QuantumRegister> &qregs, std::vector<ClassicalRegister> &cregs, const double global_phase)
+QuantumCircuit::QuantumCircuit(std::vector<QuantumRegister> qregs, std::vector<ClassicalRegister> cregs, const double global_phase)
 {
     num_qubits_ = 0;
     num_clbits_ = 0;
@@ -105,7 +105,7 @@ QuantumCircuit::QuantumCircuit(std::vector<QuantumRegister> &qregs, std::vector<
         num_clbits_ += cregs[i].size();
     }
 
-    rust_circuit_ = std::shared_ptr<rust_circuit>(qk_circuit_new((std::uint32_t)num_qubits_, (std::uint32_t)num_clbits_), qk_circuit_free);
+    rust_circuit_ = std::shared_ptr<rust_circuit>(qk_circuit_new(0, 0), qk_circuit_free);
 
     for (uint_t i = 0; i < qregs_.size(); i++)
     {
@@ -158,19 +158,13 @@ QuantumCircuit QuantumCircuit::copy(void)
     return copied;
 }
 
-void QuantumCircuit::from_rust_circuit(std::shared_ptr<rust_circuit> circ, const std::vector<uint32_t> &map)
+void QuantumCircuit::set_qiskit_circuit(std::shared_ptr<rust_circuit> circ, const std::vector<uint32_t> &map)
 {
     if (rust_circuit_)
         rust_circuit_.reset();
     rust_circuit_ = circ;
     num_qubits_ = qk_circuit_num_qubits(circ.get());
     num_clbits_ = qk_circuit_num_clbits(circ.get());
-
-    qregs_.resize(1);
-    cregs_.resize(1);
-
-    qregs_[0].resize(num_qubits_);
-    cregs_[0].resize(num_clbits_);
 
     qubit_map_.resize(map.size());
     for (int i = 0; i < map.size(); i++)

--- a/src/circuit/register.hpp
+++ b/src/circuit/register.hpp
@@ -150,7 +150,7 @@ public:
 
     /// @brief Return the name of this register
     /// @return the name of this register
-    std::string name() { return name_; }
+    const std::string& name() const { return name_; }
 
     void set_base_index(uint_t base)
     {

--- a/src/compiler/transpiler.hpp
+++ b/src/compiler/transpiler.hpp
@@ -59,8 +59,8 @@ circuit::QuantumCircuit transpile(circuit::QuantumCircuit &circ, providers::Back
     std::vector<uint32_t> layout_map(qk_transpile_layout_num_output_qubits(result.layout));
     qk_transpile_layout_final_layout(result.layout, false, layout_map.data());
 
-    circuit::QuantumCircuit transpiled;
-    transpiled.from_rust_circuit(std::shared_ptr<rust_circuit>(result.circuit, qk_circuit_free), layout_map);
+    circuit::QuantumCircuit transpiled = circ;
+    transpiled.set_qiskit_circuit(std::shared_ptr<rust_circuit>(result.circuit, qk_circuit_free), layout_map);
     transpiled.set_target(target);
 
     qk_transpile_layout_free(result.layout);

--- a/src/primitives/containers/sampler_pub.hpp
+++ b/src/primitives/containers/sampler_pub.hpp
@@ -74,7 +74,7 @@ public:
 
     /// @brief Return a QuantumCircuit for this sampler pub
     /// @return a quantum circuit
-    circuit::QuantumCircuit& circuit(void)
+    const circuit::QuantumCircuit& circuit(void) const
     {
         return circuit_;
     }

--- a/src/utils/bitvector.hpp
+++ b/src/utils/bitvector.hpp
@@ -18,6 +18,7 @@
 #define __qiskitcpp_utils_bit_vector_hpp__
 
 #include "utils/types.hpp"
+#include "utils/utils.hpp"
 
 namespace Qiskit
 {
@@ -103,6 +104,12 @@ public:
         bits_[vpos] |= ((val & elem_mask_) << bpos);
     }
 
+    /// @brief Return subsets of the BitVector
+    /// @param start_bit start bit index of subset
+    /// @param num_bits number of bits in a subset
+    /// @return A new BitVector
+    BitVector get_subset(const uint_t start_bit, const uint_t num_bits);
+
     // convert from other data
     void from_uint(const uint_t src, const uint_t n, const uint_t base = 2);
     void from_string(const std::string &src, const uint_t base = 2);
@@ -115,6 +122,10 @@ public:
     std::string to_string();
     std::string to_hex_string();
     reg_t to_vector();
+
+    /// @brief Return number of 1 bits
+    /// @return A number of 1 bits
+    uint_t popcount(void);
 };
 
 void BitVector::allocate(uint_t n, uint_t base)
@@ -298,7 +309,27 @@ reg_t BitVector::to_vector(void)
     return ret;
 }
 
-    //------------------------------------------------------------------------------
+BitVector BitVector::get_subset(const uint_t start_bit, const uint_t num_bits)
+{
+    BitVector ret(num_bits);
+
+    for (uint_t i = 0; i < num_bits; i++) {
+        ret.set(i, get(start_bit + i));
+    }
+    return ret;
+}
+
+uint_t BitVector::popcount(void)
+{
+    uint_t count = 0;
+    for (uint_t i = 0; i < bits_.size(); i++) {
+        count += Qiskit::popcount(bits_[i]);
+    }
+    return count;
+}
+
+
+//------------------------------------------------------------------------------
 } // namespace Qiskit
 //------------------------------------------------------------------------------
 #endif // __qiskitcpp_utils_bit_vector_hpp__

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -1,0 +1,83 @@
+/*
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+*/
+
+#ifndef __qiskitcpp_utils_hpp__
+#define __qiskitcpp_utils_hpp__
+
+#include "utils/types.hpp"
+
+#if defined(__linux__)
+#include <unistd.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#elif defined(_MSC_VER)
+#include <windows.h>
+#endif
+
+namespace Qiskit {
+
+
+#ifdef _MSC_VER
+#define POPCNT __popcnt64
+#define INTRINSIC_PARITY 1
+inline bool _intrinsic_parity(uint_t x) { return (POPCNT(x) & 1U); }
+inline uint_t _instrinsic_weight(uint_t x) { return (POPCNT(x)); }
+#endif
+#ifdef __GNUC__
+#define INTRINSIC_PARITY 1
+inline bool _intrinsic_parity(uint_t x) {
+    return (__builtin_popcountll(x) & 1U);
+}
+inline uint_t _instrinsic_weight(uint_t x) { return (__builtin_popcountll(x)); }
+#endif
+#ifdef _CLANG_
+#if __has__builtin(__builtin_popcount)
+#define INTRINSIC_PARITY 1
+inline bool _intrinsic_parity(uint_t x) {
+    return (__builtin_popcountll(x) & 1U);
+}
+inline uint_t _instrinsic_weight(uint_t x) { return (__builtin_popcountll(x)); }
+#endif
+#endif
+
+uint_t _naive_weight(uint_t x) {
+    auto count = x;
+    count = (count & 0x5555555555555555) + ((count >> 1) & 0x5555555555555555);
+    count = (count & 0x3333333333333333) + ((count >> 2) & 0x3333333333333333);
+    count = (count & 0x0f0f0f0f0f0f0f0f) + ((count >> 4) & 0x0f0f0f0f0f0f0f0f);
+    count = (count & 0x00ff00ff00ff00ff) + ((count >> 8) & 0x00ff00ff00ff00ff);
+    count = (count & 0x0000ffff0000ffff) + ((count >> 16) & 0x0000ffff0000ffff);
+    count = (count & 0x00000000ffffffff) + ((count >> 32) & 0x00000000ffffffff);
+    return count;
+}
+
+inline bool _naive_parity(uint_t x) {
+    return (_naive_weight(x) & 1U);
+}
+
+
+#ifdef INTRINSIC_PARITY
+bool (*hamming_parity)(uint_t) = &_intrinsic_parity;
+uint_t (*popcount)(uint_t) = &_instrinsic_weight;
+#else
+bool (*hamming_parity)(uint_t) = &_naive_parity;
+uint_t (*popcount)(uint_t) = &_naive_weight;
+#endif
+
+
+} // namespace Qiskit
+
+#endif
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds support for measuring and stores to multiple classical registers.
Also adds functions in `BitArray` class as similar to Python's Qiskit to get bitcount and indexed data access.

### Details and comments

There was no function to store to multiple classical registers before. And Sampler returns all the measured bits in a single `BitArray` data.
Now sampler pub result can return separate `BitArray` for each classical registers. 

`BitArray` adds new functions. `bitcount` returns number of 1 bits in each bitstrings.
`get_counts` can have a list of index which element should be included in the map of counts

