### PR TITLE
Fix num_qubits() and num_clbits() methods

### DIFF
--- a/src/circuit/quantumcircuit_def.hpp
+++ b/src/circuit/quantumcircuit_def.hpp
@@ -104,10 +104,6 @@ public:
 	/// @return number of qubits
 	uint_t num_qubits(void) const
 	{
-		if (target_)
-		{
-			return target_->num_qubits();
-		}
 		return num_qubits_;
 	}
 
@@ -115,10 +111,6 @@ public:
 	/// @return number of classical bits
 	uint_t num_clbits(void) const
 	{
-		if (target_)
-		{
-			return target_->num_qubits();
-		}
 		return num_clbits_;
 	}
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The num bits methods were incorrectly querying the target stored with the circuit, when present, for the number of bits instead of the actual circuit attributes. This commit fixes this issue so the circuit bit counts are correctly returned.

There is a larger question around why the circuit is locally storing the bit counts instead of just querying the inner qiskit circuit object. But for just fixing this issue I kept the change minimal rather than removing the protected attribute. We can do that in a follow up if needed.

### Details and comments


