### PR TITLE
Fix for Qiskit IBM Runtime C

### DIFF
--- a/samples/sampler_test.cpp
+++ b/samples/sampler_test.cpp
@@ -22,7 +22,12 @@
 
 #include "circuit/quantumcircuit.hpp"
 #include "primitives/backend_sampler_v2.hpp"
+#ifdef QRMI_ROOT
 #include "service/qiskit_runtime_service_qrmi.hpp"
+#else
+#include "service/qiskit_runtime_service_c.hpp"
+#endif
+
 #include "compiler/transpiler.hpp"
 
 using namespace Qiskit;

--- a/samples/transpile_test.cpp
+++ b/samples/transpile_test.cpp
@@ -23,7 +23,11 @@
 #include "circuit/quantumcircuit.hpp"
 #include "primitives/backend_sampler_v2.hpp"
 
+#ifdef QRMI_ROOT
 #include "service/qiskit_runtime_service_qrmi.hpp"
+#else
+#include "service/qiskit_runtime_service_c.hpp"
+#endif
 #include "compiler/transpiler.hpp"
 
 using namespace Qiskit::circuit;
@@ -50,12 +54,12 @@ int main()
   }
 
   std::cout << "input circuit" << std::endl;
-  circ.print();
+  circ.draw();
 
   auto transpiled = transpile(circ, backend);
 
   std::cout << "transpiled circuit" << std::endl;
-  transpiled.print();
+  transpiled.draw();
 
   return 0;
 }

--- a/src/compiler/transpiler.hpp
+++ b/src/compiler/transpiler.hpp
@@ -45,7 +45,7 @@ circuit::QuantumCircuit transpile(circuit::QuantumCircuit &circ, providers::Back
     options.seed = seed_transpiler;
     options.approximation_degree = approximation_degree;
 
-    QkTranspileResult result;
+    QkTranspileResult result = {nullptr, nullptr};
     char *error;
 
     QkExitCode ret = qk_transpile(circ.get_rust_circuit().get(), capi_target, &options, &result, &error);

--- a/src/primitives/containers/bit_array.hpp
+++ b/src/primitives/containers/bit_array.hpp
@@ -77,6 +77,12 @@ public:
         return array_.size();
     }
 
+    /// @brief accessing raw bit array
+    BitVector& operator[](const uint_t i)
+    {
+        return array_[i];
+    }
+
     // from simulator samples (< 64 qubits)
     void from_samples(const reg_t& samples, uint_t num_bits);
     void from_samples(const uint_t* samples, uint_t num_samples, uint_t num_bits);

--- a/src/primitives/containers/sampler_pub_result.hpp
+++ b/src/primitives/containers/sampler_pub_result.hpp
@@ -137,6 +137,20 @@ public:
         }
     }
 
+    /// @brief add bitstring by hexstring
+    /// @param str hexstring to be added in data
+    void set_hexstring(const uint_t i, const std::string& str)
+    {
+        BitVector bits;
+        bits.from_hex_string(str);
+
+        uint_t pos = 0;
+        // split bitstring and store for each creg
+        for (auto creg : pub_.circuit().cregs()) {
+            data_[creg.name()][i] = bits.get_subset(pos, creg.size());
+            pos += creg.size();
+        }
+    }
 };
 
 } // namespace primitives

--- a/src/providers/qkrt_job.hpp
+++ b/src/providers/qkrt_job.hpp
@@ -106,7 +106,7 @@ public:
     bool result(uint_t index, primitives::SamplerPubResult& result) override
     {
         Samples *samples;
-        int ret = qkrt_job_results(&samples, service_.get(), job_.get());
+        int ret = qkrt_sampler_job_results(&samples, service_.get(), job_.get());
         if (ret != 0) {
             std::cerr << "ERROR: qkrt_job_results fails with code " << ret << std::endl;
             return false;
@@ -116,7 +116,7 @@ public:
         for (size_t i = 0; i< num_samples; i++) {
             char* sample = qkrt_samples_get_sample(samples, i);
             std::string ss(sample);
-            result.data().set_hexstring(i, ss);
+            result.set_hexstring(i, ss);
             qkrt_str_free(sample);
         }
         qkrt_samples_free(samples);

--- a/src/transpiler/target.hpp
+++ b/src/transpiler/target.hpp
@@ -64,6 +64,9 @@ public:
     Target(QkTarget* target)
     {
         target_ = std::shared_ptr<QkTarget>(target, qk_target_free);
+        num_qubits_ = qk_target_num_qubits(target);
+        dt_ = qk_target_dt(target);
+        is_set_ = true;
     }
 
     /// @brief Create a new target


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is fix for Qiskit IBM Runtime C
including fix for #140 

### Details and comments

For #140 sampler and transpiler tests always includes `qiskit_runtime_service_qrmi.hpp` that causes `qrmi.h` not found error.
This PR add pre-processor to include proper header file.

For Qiskit IBM Runtime C, sampled bitstrings are merged into one bitstring for multiple cregs. In `SamplerPubResult` this PR separates the bitstrings into each creg

